### PR TITLE
Let the size of the 2nd figure be same as the 1st

### DIFF
--- a/scripts/knn_voronoi_plot.py
+++ b/scripts/knn_voronoi_plot.py
@@ -1,5 +1,3 @@
-
-
 import numpy as np
 import matplotlib.pyplot as plt
 import os
@@ -10,20 +8,22 @@ from scipy.spatial import KDTree, Voronoi, voronoi_plot_2d
 
 np.random.seed(42)
 data = np.random.rand(25, 2)
-tree = KDTree(data)
 vor = Voronoi(data)
-x = np.linspace(0, 1, 200)
-y = np.linspace(0, 1, 200)
-xx, yy = np.meshgrid(x, y)
-xy = np.c_[xx.ravel(), yy.ravel()]
 
 print('Using scipy.spatial.voronoi_plot_2d, wait...')
 voronoi_plot_2d(vor)
+xlim = plt.xlim()
+ylim = plt.ylim()
 save_fig('knnVoronoiMesh.pdf')
 plt.show()
 
 print('Using scipy.spatial.KDTree, wait a few seconds...')
 plt.figure()
+tree = KDTree(data)
+x = np.linspace(xlim[0], xlim[1], 200)
+y = np.linspace(ylim[0], ylim[1], 200)
+xx, yy = np.meshgrid(x, y)
+xy = np.c_[xx.ravel(), yy.ravel()]
 plt.plot(data[:, 0], data[:, 1], 'ko')
 plt.pcolormesh(x, y, tree.query(xy)[1].reshape(200, 200), cmap='jet')
 save_fig('knnVoronoiColor.pdf')


### PR DESCRIPTION
Original version use

```
x = np.linspace(0, 1, 200)
y = np.linspace(0, 1, 200)
```
while xlim and ylim of the figure generated by `voronoi_plot_2d` does not have to be [0, 1].