### PR TITLE
Update dtree_sensitivity.py

### DIFF
--- a/scripts/dtree_sensitivity.py
+++ b/scripts/dtree_sensitivity.py
@@ -117,6 +117,7 @@ if 0:
     eclf = VotingClassifier(
         estimators=[('orig', tree_clf), ('tweaked', tree_clf_tweaked)],
         voting='hard')
+    eclf.fit(X, y)
     plot_surface(eclf, X, y, xnames, ynames)
     
 from prefit_voting_classifier import PrefitVotingClassifier


### PR DESCRIPTION
Call 'fit' with appropriate arguments before using this estimator.
This is not PR, but The last image "dtree_iris_depth2_ensemble.pdf" can't be saved because "fit" function is not implemented in "prefit_voting_classifier.py".
and the link of this script is broken.