### PR TITLE
Added implementation of gaussInferParamsMean1d

### DIFF
--- a/scripts/gaussInferParamsMean1d.py
+++ b/scripts/gaussInferParamsMean1d.py
@@ -34,7 +34,7 @@ for i in priorVar:
     
     x = np.arange(-5,5.25, 0.25)
 
-    fig = plt.figure(figsize = (6, 6))
+    fig = plt.figure(figsize = (4, 4))
     plt.ylim(0,0.6)
     plt.xlim(-5,5)
     plt.xticks([-5,0,5])
@@ -45,5 +45,5 @@ for i in priorVar:
     plt.plot(x, multivariate_normal.pdf(x, mean = post_mu, cov = post_Sigma), color = "black", 
              label = "post",linestyle='dashdot')
     plt.title(f"prior variance of {i}")
-    plt.legend()
+    plt.legend(loc="upper left")
     plt.savefig(f"../figures/gaussInferParamsMean1dvectorQuantization_{i}.pdf", dpi=300)

--- a/scripts/gaussInferParamsMean1d.py
+++ b/scripts/gaussInferParamsMean1d.py
@@ -1,0 +1,49 @@
+# Implementation of gaussInferParamsMean1d
+# Author: Animesh Gupta
+
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.stats import multivariate_normal
+
+
+priorVar = [1, 5]
+Sigma = 1 # Assumed to be known
+X = 3 
+post_mu = 0
+post_Sigma = 0
+
+for i in priorVar:
+    
+    prior_Sigma = i
+    prior_mu    = 0
+    xbar = np.mean(X)
+    n    = np.size(X)
+    
+    lik_Sigma = Sigma
+    lik_mu    = xbar
+    
+    S0    = prior_Sigma
+    S0inv = 1./S0
+    mu0   = prior_mu
+    S     = Sigma
+    Sinv  = 1./S
+    Sn    = 1./(S0inv + n*Sinv)
+    
+    post_mu    = Sn*(n*Sinv*xbar + S0inv*mu0)
+    post_Sigma = Sn
+    
+    x = np.arange(-5,5.25, 0.25)
+
+    fig = plt.figure(figsize = (6, 6))
+    plt.ylim(0,0.6)
+    plt.xlim(-5,5)
+    plt.xticks([-5,0,5])
+    plt.plot(x, multivariate_normal.pdf(x, mean = prior_mu, cov = prior_Sigma), color = "blue", 
+             label = "prior")
+    plt.plot(x, multivariate_normal.pdf(x, mean = lik_mu, cov = lik_Sigma), color = "red", 
+             label = "lik",linestyle='dotted')
+    plt.plot(x, multivariate_normal.pdf(x, mean = post_mu, cov = post_Sigma), color = "black", 
+             label = "post",linestyle='dashdot')
+    plt.title(f"prior variance of {i}")
+    plt.legend()
+    plt.savefig(f"../figures/gaussInferParamsMean1dvectorQuantization_{i}.pdf", dpi=300)


### PR DESCRIPTION
Added python implementation of gaussInferParamsMean1d.
Fixes #177 
<img width="557" alt="Screen Shot 2021-03-14 at 4 29 43 PM" src="https://user-images.githubusercontent.com/53366877/111065992-b93a1980-84e2-11eb-9dff-eeef3952d5b4.png">
<img width="552" alt="Screen Shot 2021-03-14 at 4 30 08 PM" src="https://user-images.githubusercontent.com/53366877/111065996-bd663700-84e2-11eb-9ccc-6b9e42656e97.png">
