### PR TITLE
Use jax.numpy consistently (student_pgm_inf_autodiff.py)

### DIFF
--- a/scripts/student_pgm_inf_autodiff.py
+++ b/scripts/student_pgm_inf_autodiff.py
@@ -1,9 +1,7 @@
 """
 Inference in student network using autodiff compared to pgmpy.
-
 Network is from
 https://github.com/pgmpy/pgmpy_notebook/blob/master/notebooks/2.%20Bayesian%20Networks.ipynb
-
 I     D
 | \   /
 v   v
@@ -15,9 +13,8 @@ S   G
 All nodes are binary except G (grade), which has 3 levels.
 """
     
-import numpy as onp # original numpy
-import jax.numpy as np
-
+import numpy as  np # original numpy
+import jax.numpy as jnp
 
 import bayesnet_inf_autodiff as bn
 
@@ -25,19 +22,18 @@ from pgmpy.models import BayesianModel
 from pgmpy.factors.discrete import TabularCPD
 from pgmpy.inference import VariableElimination
 
-
 dag = {'I':[], 'D':[], 'G':['I','D'], 'S':['I'], 'L':['G']}
-paramsD = np.array([0.6, 0.4])
-paramsI = np.array([0.7, 0.3])
-paramsG = np.array([[0.3, 0.05, 0.9,  0.5],
+paramsD = jnp.array([[0.6, 0.4]])
+paramsI = jnp.array([[0.7, 0.3]])
+paramsG = jnp.array([[0.3, 0.05, 0.9,  0.5],
                       [0.4, 0.25, 0.08, 0.3],
                       [0.3, 0.7,  0.02, 0.2]])
-paramsG = np.reshape(paramsG, (3,2,2)) # paramsG[G,I,D]
-paramsL = np.array([[0.1, 0.4, 0.99],
+paramsG = jnp.reshape(paramsG, (3,2,2)) # paramsG[G,I,D]
+paramsL = jnp.array([[0.1, 0.4, 0.99],
                     [0.9, 0.6, 0.01]])
-paramsS = np.array([[0.95, 0.2],
+paramsS = jnp.array([[0.95, 0.2],
                     [0.05, 0.8]])
-params = {'D': paramsD, 'I': paramsI, 'G': paramsG, 'L': paramsL, 'S': paramsS}
+params = {'I': paramsI, 'D': paramsD, 'G': paramsG, 'S': paramsS, 'L': paramsL}
 
 inf_engine_ad = bn.BayesNetInfAutoDiff(dag, params)
 
@@ -76,14 +72,13 @@ cpd_s = TabularCPD(variable='S', variable_card=2,
                    evidence=['I'],
                    evidence_card=[2])
 
-
 model.add_cpds(cpd_d, cpd_i, cpd_g, cpd_l, cpd_s)
 model.check_model()
 inf_engine_ve = VariableElimination(model) # compute elim order only once
 
 def infer_pgmpy(evidence, query):
     factor = inf_engine_ve.query([query], evidence=evidence) [query]
-    marginal = factor.values # convert from DiscreteFactor to np array
+    marginal = factor.values # convert from DiscreteFactor to jnp array
     return marginal
 
 ## Check both inference engines give same posterior marginals 
@@ -99,6 +94,4 @@ for evidence in evlist:
     for query in hid_nodes:
         prob_ad = infer_autodiff(evidence, query)
         prob_pgm = infer_pgmpy(evidence, query)
-        assert onp.allclose(prob_ad, prob_pgm)
-
-    
+        assert  np.allclose(prob_ad, prob_pgm)


### PR DESCRIPTION
In `student_pgm_inf_autodiff.py`, `BayesNetInfAutoDiff` class of `bayesnet_inf_autodif.py` is used. I would like to know why in the `make_list_of_factors()` function the `evecs` (evidence vectors) and `cpts` (params) lists are merged? In line `return (evecs+cpts)`. Doing so gives the error “ValueError: Number of einsum subscripts must be equal to the number of operands” dag and params are passed in `bn.BayesNetInfAutoDiff(dag, params)`.  @murphyk please solve my query. Thanks. 
