### PR TITLE
Convert_LinearRobustDemoCombined_to_python

### DIFF
--- a/scripts/linearrobustdemocombined.py
+++ b/scripts/linearrobustdemocombined.py
@@ -1,0 +1,109 @@
+import pyprobml_utils as pml
+
+import matplotlib.pyplot as plt 
+from sklearn.linear_model import LinearRegression
+from sklearn.linear_model import HuberRegressor
+import numpy as np
+import pandas as pd
+from statsmodels.miscmodels.tmodel import TLinearModel
+import statsmodels.api as sm
+
+#!pip install statsmodels
+
+"""Dataset according to the matlab code and book"""
+
+np.random.seed(1) 
+x = np.random.uniform(low=0.3, high=1.1, size=(10,)) 
+x = x.flatten()
+x = np.sort(x)
+
+y = (np.random.rand(len(x))-0.5 + 1 + 2*x)
+y = y.flatten()
+y = np.sort(y)
+
+x = np.append(x, 0.1)
+x = np.append(x, 0.5)
+x = np.append(x, 0.9)
+x = x.reshape(-1, 1)
+
+y = np.append(y, -5)
+y = np.append(y, -5)
+y = np.append(y, -5)
+y = y.reshape(-1, 1)
+
+x_test = np.arange(0, 1.1, 0.1)
+x_test = x_test.reshape((len(x_test), 1))
+
+xmax = 1 #np.max(x)
+xmin = 0 #np.min(x)
+ymax = 4 #np.max(y) 
+ymin = -6 #np.min(y)
+
+"""L2"""
+
+reg1 = LinearRegression()
+
+model1 = reg1.fit(x, y)
+y_pred1 = model1.predict(x_test)
+
+"""Huber"""
+
+reg2 = HuberRegressor(epsilon = 1.0)
+
+model2 = reg2.fit(x, y)
+y_pred2 = model2.predict(x_test)
+
+"""L1"""
+
+def MAE_weights_updation(m, b, X, Y, learning_rate):
+    m_deriv = 0
+    b_deriv = 0
+    N = len(X)
+    for i in range(N):
+        # Calculate partial derivatives
+        m_deriv += - X[i] * (Y[i] - (m*X[i] + b)) / abs(Y[i] - (m*X[i] + b))
+        b_deriv += -(Y[i] - (m*X[i] + b)) / abs(Y[i] - (m*X[i] + b))
+
+    # Updating in direction of steepest ascent
+    m -= (m_deriv / float(N)) * learning_rate
+    b -= (b_deriv / float(N)) * learning_rate
+
+    return m, b
+
+m_new = 1
+b_new = 1
+learning_rate = 0.1
+epochs = 100
+
+for i in range(epochs):
+  m_old, b_old = m_new, b_new 
+  m_new, b_new = MAE_weights_updation(m_old, b_old, x, y, learning_rate)
+
+y_pred4 = m_new*x_test + b_new
+
+"""Student-t"""
+
+dfx = pd.DataFrame(x, columns = ['x'])
+dfy = pd.DataFrame(y, columns = ['y'])
+exog = sm.add_constant(dfx['x'])
+endog = dfy['y']
+
+tmodel = TLinearModel(endog, exog)
+results = tmodel.fit(df=0.6)
+
+dft = pd.DataFrame(x_test, columns = ['test'])
+
+ypred_t = np.dot(dft, results.params[1]) + results.params[0] #results.predict(dft)
+
+plt.xlim(xmin, xmax)
+plt.ylim(ymin, ymax)
+plt.yticks(np.arange(ymin, ymax, 1.0))
+plt.scatter(x, y, color="none", edgecolor="black")
+plt.plot(x_test, y_pred1, '-.', color='black') #Least squares
+plt.plot(x_test, y_pred2, '--', color='green') #Huber
+plt.plot(x_test, ypred_t, color='red')         #student
+plt.plot(x_test, y_pred4, '--', color='blue')  #Laplace
+plt.legend(["Least squares", "Huber, \u0394 =1", "Student-t, \u03BD =0.6", "Laplace"])
+pml.save_fig('Robust.png')
+plt.savefig('Robust.png')
+plt.show()

--- a/scripts/linearrobustdemocombined.py
+++ b/scripts/linearrobustdemocombined.py
@@ -1,18 +1,19 @@
 import pyprobml_utils as pml
-
 import matplotlib.pyplot as plt 
 from sklearn.linear_model import LinearRegression
 from sklearn.linear_model import HuberRegressor
 import numpy as np
 import pandas as pd
 from statsmodels.miscmodels.tmodel import TLinearModel
+from statsmodels.regression.quantile_regression import QuantReg
 import statsmodels.api as sm
+import statsmodels.formula.api as smf
 
 #!pip install statsmodels
 
 """Dataset according to the matlab code and book"""
 
-np.random.seed(1) 
+np.random.seed(1) #1
 x = np.random.uniform(low=0.3, high=1.1, size=(10,)) 
 x = x.flatten()
 x = np.sort(x)
@@ -48,52 +49,32 @@ y_pred1 = model1.predict(x_test)
 
 """Huber"""
 
-reg2 = HuberRegressor(epsilon = 1.0)
+reg2 = HuberRegressor(epsilon = 1)
 
 model2 = reg2.fit(x, y)
 y_pred2 = model2.predict(x_test)
 
 """L1"""
 
-def MAE_weights_updation(m, b, X, Y, learning_rate):
-    m_deriv = 0
-    b_deriv = 0
-    N = len(X)
-    for i in range(N):
-        # Calculate partial derivatives
-        m_deriv += - X[i] * (Y[i] - (m*X[i] + b)) / abs(Y[i] - (m*X[i] + b))
-        b_deriv += -(Y[i] - (m*X[i] + b)) / abs(Y[i] - (m*X[i] + b))
-
-    # Updating in direction of steepest ascent
-    m -= (m_deriv / float(N)) * learning_rate
-    b -= (b_deriv / float(N)) * learning_rate
-
-    return m, b
-
-m_new = 1
-b_new = 1
-learning_rate = 0.1
-epochs = 100
-
-for i in range(epochs):
-  m_old, b_old = m_new, b_new 
-  m_new, b_new = MAE_weights_updation(m_old, b_old, x, y, learning_rate)
-
-y_pred4 = m_new*x_test + b_new
-
-"""Student-t"""
-
 dfx = pd.DataFrame(x, columns = ['x'])
 dfy = pd.DataFrame(y, columns = ['y'])
 exog = sm.add_constant(dfx['x'])
 endog = dfy['y']
+dft = pd.DataFrame(x_test, columns = ['test'])
+
+qrmodel = QuantReg(endog, exog)
+result = qrmodel.fit(q=0.5)
+
+ypred_qr = np.dot(dft, result.params[1]) + result.params[0] #results.predict(dft)
+
+"""Student-t"""
 
 tmodel = TLinearModel(endog, exog)
 results = tmodel.fit(df=0.6)
 
-dft = pd.DataFrame(x_test, columns = ['test'])
-
 ypred_t = np.dot(dft, results.params[1]) + results.params[0] #results.predict(dft)
+
+"""Plot"""
 
 plt.xlim(xmin, xmax)
 plt.ylim(ymin, ymax)
@@ -102,7 +83,7 @@ plt.scatter(x, y, color="none", edgecolor="black")
 plt.plot(x_test, y_pred1, '-.', color='black') #Least squares
 plt.plot(x_test, y_pred2, '--', color='green') #Huber
 plt.plot(x_test, ypred_t, color='red')         #student
-plt.plot(x_test, y_pred4, '--', color='blue')  #Laplace
+plt.plot(x_test, ypred_qr, '--', color='blue') 
 plt.legend(["Least squares", "Huber, \u0394 =1", "Student-t, \u03BD =0.6", "Laplace"])
 pml.save_fig('Robust.png')
 plt.savefig('Robust.png')


### PR DESCRIPTION
@murphyk and @mjsML , please review this code. Here, I have tried to use `sklearn` as much as possible and the `statsmodels` package has been useful for student-t distribution loss. In the statsmodels package, in the files, edgeworth.py, markov_switching.py, kernels.py, functional.py, moment_helpers.py imports like `from scipy.misc import factorial` or from` scipy.misc import logsumexp` should be changed to `scipy.special import factorial/logsumexp` as these functions are located in `scipy.special` (for scipy >=1.3.0)

Closes #203 
![Robust](https://user-images.githubusercontent.com/35187749/116304951-bb211900-a7c0-11eb-86f7-ef3253eddd74.png)

Fig. 11.9 :


 