### PR TITLE
Visualize posterior marginals of a discrete graphical model

### DIFF
--- a/notebooks/asia_pgm.ipynb
+++ b/notebooks/asia_pgm.ipynb
@@ -1,0 +1,865 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Copy of asia_pgm.ipynb",
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "caeOoFYBb5p2"
+      },
+      "source": [
+        "# The \"Asia\"  graphical model\n",
+        "\n",
+        "We illustrate inference in the \"Asia\" medical diagnosis network.\n",
+        "Network is from http://www.bnlearn.com/bnrepository/#asia.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "p4SVMjkpbcJ7",
+        "outputId": "1eaf5218-69cf-44b1-e7a9-4c19f872317e"
+      },
+      "source": [
+        "!pip install  causalgraphicalmodels\n",
+        "!pip install pgmpy\n",
+        "\n",
+        "#!ls /usr/local/lib/python3.7/dist-packages/pgmpy/utils"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Collecting causalgraphicalmodels\n",
+            "  Downloading https://files.pythonhosted.org/packages/c8/ee/3b2d184576f3cb4873cebfc696e8e5c1e53eaef691f38aea76c206f9f916/causalgraphicalmodels-0.0.4-py3-none-any.whl\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (1.1.5)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (1.19.5)\n",
+            "Requirement already satisfied: graphviz in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (0.10.1)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (2.5.1)\n",
+            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.7/dist-packages (from pandas->causalgraphicalmodels) (2.8.1)\n",
+            "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.7/dist-packages (from pandas->causalgraphicalmodels) (2018.9)\n",
+            "Requirement already satisfied: decorator<5,>=4.3 in /usr/local/lib/python3.7/dist-packages (from networkx->causalgraphicalmodels) (4.4.2)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.7/dist-packages (from python-dateutil>=2.7.3->pandas->causalgraphicalmodels) (1.15.0)\n",
+            "Installing collected packages: causalgraphicalmodels\n",
+            "Successfully installed causalgraphicalmodels-0.0.4\n",
+            "Collecting pgmpy\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/a3/0e/d9fadbfaa35e010c04d43acd3ae9fbefec98897dd7d61a6b7eb5a8b34072/pgmpy-0.1.14-py3-none-any.whl (331kB)\n",
+            "\u001b[K     |████████████████████████████████| 337kB 27.1MB/s \n",
+            "\u001b[?25hRequirement already satisfied: joblib in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.0.1)\n",
+            "Requirement already satisfied: pyparsing in /usr/local/lib/python3.7/dist-packages (from pgmpy) (2.4.7)\n",
+            "Requirement already satisfied: tqdm in /usr/local/lib/python3.7/dist-packages (from pgmpy) (4.41.1)\n",
+            "Requirement already satisfied: statsmodels in /usr/local/lib/python3.7/dist-packages (from pgmpy) (0.10.2)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.19.5)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.7/dist-packages (from pgmpy) (2.5.1)\n",
+            "Requirement already satisfied: scipy in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.4.1)\n",
+            "Requirement already satisfied: torch in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.8.1+cu101)\n",
+            "Requirement already satisfied: scikit-learn in /usr/local/lib/python3.7/dist-packages (from pgmpy) (0.22.2.post1)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.1.5)\n",
+            "Requirement already satisfied: patsy>=0.4.0 in /usr/local/lib/python3.7/dist-packages (from statsmodels->pgmpy) (0.5.1)\n",
+            "Requirement already satisfied: decorator<5,>=4.3 in /usr/local/lib/python3.7/dist-packages (from networkx->pgmpy) (4.4.2)\n",
+            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from torch->pgmpy) (3.7.4.3)\n",
+            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.7/dist-packages (from pandas->pgmpy) (2.8.1)\n",
+            "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.7/dist-packages (from pandas->pgmpy) (2018.9)\n",
+            "Requirement already satisfied: six in /usr/local/lib/python3.7/dist-packages (from patsy>=0.4.0->statsmodels->pgmpy) (1.15.0)\n",
+            "Installing collected packages: pgmpy\n",
+            "Successfully installed pgmpy-0.1.14\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Go1UPp8eMIyC"
+      },
+      "source": [
+        "from causalgraphicalmodels import CausalGraphicalModel\n",
+        "import pgmpy\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "from graphviz import Digraph"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "u_-A-Hai4LbM"
+      },
+      "source": [
+        "# Model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Il1OHrxj3e8Y"
+      },
+      "source": [
+        "#from pgmpy.utils import get_example_model\n",
+        "#asia = get_example_model('asia')\n",
+        "# No such file or directory: 'pgmpy/utils/example_models/asia.bif.gz'"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "OGsv1dt81oyI"
+      },
+      "source": [
+        "#!wget https://raw.githubusercontent.com/d2l-ai/d2l-en/master/d2l/torch.py -q -O d2l.py\n",
+        "\n",
+        "!wget https://www.bnlearn.com/bnrepository/asia/asia.bif.gz -q -O asia.bif.gz\n",
+        "!gunzip asia.bif.gz"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "l8xzIiLr0En0",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "eb4bc173-dc8b-48e6-f112-6dc095bf0797"
+      },
+      "source": [
+        "from pgmpy.readwrite import BIFReader, BIFWriter\n",
+        "reader = BIFReader(\"asia.bif\")\n",
+        "model = reader.get_model()\n",
+        "\n",
+        "print(\"Nodes: \", model.nodes())\n",
+        "print(\"Edges: \", model.edges())\n",
+        "model.get_cpds()"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Nodes:  ['asia', 'tub', 'smoke', 'lung', 'bronc', 'either', 'xray', 'dysp']\n",
+            "Edges:  [('asia', 'tub'), ('tub', 'either'), ('smoke', 'lung'), ('smoke', 'bronc'), ('lung', 'either'), ('bronc', 'dysp'), ('either', 'xray'), ('either', 'dysp')]\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[<TabularCPD representing P(asia:2) at 0x7fa5e0d08790>,\n",
+              " <TabularCPD representing P(bronc:2 | smoke:2) at 0x7fa5dd8db890>,\n",
+              " <TabularCPD representing P(dysp:2 | bronc:2, either:2) at 0x7fa5dd8db8d0>,\n",
+              " <TabularCPD representing P(either:2 | lung:2, tub:2) at 0x7fa5dd8db750>,\n",
+              " <TabularCPD representing P(lung:2 | smoke:2) at 0x7fa5e1c97f90>,\n",
+              " <TabularCPD representing P(smoke:2) at 0x7fa5dd906290>,\n",
+              " <TabularCPD representing P(tub:2 | asia:2) at 0x7fa5dd906c90>,\n",
+              " <TabularCPD representing P(xray:2 | either:2) at 0x7fa5dd906b90>]"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 5
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "d1GFKz5t5kxA",
+        "outputId": "530e241b-b18e-4639-cf12-1598965792ce"
+      },
+      "source": [
+        "for c in model.get_cpds():\n",
+        "  print(c)"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "+-----------+------+\n",
+            "| asia(yes) | 0.01 |\n",
+            "+-----------+------+\n",
+            "| asia(no)  | 0.99 |\n",
+            "+-----------+------+\n",
+            "+------------+------------+-----------+\n",
+            "| smoke      | smoke(yes) | smoke(no) |\n",
+            "+------------+------------+-----------+\n",
+            "| bronc(yes) | 0.6        | 0.3       |\n",
+            "+------------+------------+-----------+\n",
+            "| bronc(no)  | 0.4        | 0.7       |\n",
+            "+------------+------------+-----------+\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "| bronc     | bronc(yes)  | bronc(yes) | bronc(no)   | bronc(no)  |\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "| either    | either(yes) | either(no) | either(yes) | either(no) |\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "| dysp(yes) | 0.9         | 0.8        | 0.7         | 0.1        |\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "| dysp(no)  | 0.1         | 0.2        | 0.3         | 0.9        |\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "| lung        | lung(yes) | lung(yes) | lung(no) | lung(no) |\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "| tub         | tub(yes)  | tub(no)   | tub(yes) | tub(no)  |\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "| either(yes) | 1.0       | 1.0       | 1.0      | 0.0      |\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "| either(no)  | 0.0       | 0.0       | 0.0      | 1.0      |\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "+-----------+------------+-----------+\n",
+            "| smoke     | smoke(yes) | smoke(no) |\n",
+            "+-----------+------------+-----------+\n",
+            "| lung(yes) | 0.1        | 0.01      |\n",
+            "+-----------+------------+-----------+\n",
+            "| lung(no)  | 0.9        | 0.99      |\n",
+            "+-----------+------------+-----------+\n",
+            "+------------+-----+\n",
+            "| smoke(yes) | 0.5 |\n",
+            "+------------+-----+\n",
+            "| smoke(no)  | 0.5 |\n",
+            "+------------+-----+\n",
+            "+----------+-----------+----------+\n",
+            "| asia     | asia(yes) | asia(no) |\n",
+            "+----------+-----------+----------+\n",
+            "| tub(yes) | 0.05      | 0.01     |\n",
+            "+----------+-----------+----------+\n",
+            "| tub(no)  | 0.95      | 0.99     |\n",
+            "+----------+-----------+----------+\n",
+            "+-----------+-------------+------------+\n",
+            "| either    | either(yes) | either(no) |\n",
+            "+-----------+-------------+------------+\n",
+            "| xray(yes) | 0.98        | 0.05       |\n",
+            "+-----------+-------------+------------+\n",
+            "| xray(no)  | 0.02        | 0.95       |\n",
+            "+-----------+-------------+------------+\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "8jzeJCpE50kw",
+        "outputId": "f3511266-17c0-475c-c29e-3cc5e215952d"
+      },
+      "source": [
+        "asia_cpd = model.get_cpds()[0]\n",
+        "print(asia_cpd)\n",
+        "print(asia_cpd.values)\n",
+        "asia_prior_true = asia_cpd.values[1]"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "+-----------+------+\n",
+            "| asia(yes) | 0.01 |\n",
+            "+-----------+------+\n",
+            "| asia(no)  | 0.99 |\n",
+            "+-----------+------+\n",
+            "[0.01 0.99]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "VDNdkr0_6TsN",
+        "outputId": "1b796318-883b-440f-8ced-6614bf553be6"
+      },
+      "source": [
+        "smoking_cpd = model.get_cpds()[5]\n",
+        "print(smoking_cpd)\n",
+        "print(smoking_cpd.values)\n",
+        "smoking_prior_true = smoking_cpd.values[1]"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "+------------+-----+\n",
+            "| smoke(yes) | 0.5 |\n",
+            "+------------+-----+\n",
+            "| smoke(no)  | 0.5 |\n",
+            "+------------+-----+\n",
+            "[0.5 0.5]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "K8gIy5Bk2XJR",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 405
+        },
+        "outputId": "69d48af8-42a1-4199-c8c6-bcddf97bff99"
+      },
+      "source": [
+        "asia = CausalGraphicalModel(nodes = model.nodes(), edges=model.edges())\n",
+        "nodes = model.nodes()\n",
+        "out = asia.draw()\n",
+        "display(out)\n",
+        "out.render()"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "['asia', 'tub', 'smoke', 'lung', 'bronc', 'either', 'xray', 'dysp']\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7fa5dd8aa7d0>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: %3 Pages: 1 -->\n<svg width=\"196pt\" height=\"260pt\"\n viewBox=\"0.00 0.00 196.50 260.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 256)\">\n<title>%3</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-256 192.4971,-256 192.4971,4 -4,4\"/>\n<!-- xray -->\n<g id=\"node1\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"114.4971\" cy=\"-18\" rx=\"27.0966\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"114.4971\" y=\"-14.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">xray</text>\n</g>\n<!-- either -->\n<g id=\"node2\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"114.4971\" cy=\"-90\" rx=\"31.3957\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"114.4971\" y=\"-86.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">either</text>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M114.4971,-71.8314C114.4971,-64.131 114.4971,-54.9743 114.4971,-46.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"117.9972,-46.4132 114.4971,-36.4133 110.9972,-46.4133 117.9972,-46.4132\"/>\n</g>\n<!-- dysp -->\n<g id=\"node4\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"36.4971\" cy=\"-18\" rx=\"28.6953\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"36.4971\" y=\"-14.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">dysp</text>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M97.9553,-74.7307C87.0236,-64.6398 72.5207,-51.2526 60.3488,-40.0169\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"62.4697,-37.2115 52.7476,-33.0004 57.7217,-42.3551 62.4697,-37.2115\"/>\n</g>\n<!-- bronc -->\n<g id=\"node3\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"32.4971\" cy=\"-90\" rx=\"32.4942\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"32.4971\" y=\"-86.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">bronc</text>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M33.5065,-71.8314C33.9343,-64.131 34.443,-54.9743 34.9184,-46.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"38.414,-46.592 35.4742,-36.4133 31.4248,-46.2037 38.414,-46.592\"/>\n</g>\n<!-- tub -->\n<g id=\"node5\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"161.4971\" cy=\"-162\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"161.4971\" y=\"-158.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">tub</text>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M150.5962,-145.3008C144.8659,-136.5224 137.7166,-125.5703 131.2957,-115.7339\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"134.0624,-113.5693 125.6653,-107.1086 128.2007,-117.3956 134.0624,-113.5693\"/>\n</g>\n<!-- lung -->\n<g id=\"node6\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"88.4971\" cy=\"-162\" rx=\"27.8951\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"88.4971\" y=\"-158.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">lung</text>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M94.9241,-144.2022C97.8304,-136.1541 101.3314,-126.4588 104.5642,-117.5067\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"107.9494,-118.4369 108.054,-107.8425 101.3655,-116.0593 107.9494,-118.4369\"/>\n</g>\n<!-- smoke -->\n<g id=\"node7\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.4971\" cy=\"-234\" rx=\"35.194\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"57.4971\" y=\"-230.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">smoke</text>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M54.3814,-216.0535C50.1147,-191.4774 42.4104,-147.1008 37.3751,-118.0974\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"40.8111,-117.4266 35.6521,-108.1727 33.9143,-118.624 40.8111,-117.4266\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M65.16,-216.2022C68.6888,-208.0064 72.953,-198.1024 76.8659,-189.0145\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"80.1824,-190.162 80.9223,-179.593 73.753,-187.3938 80.1824,-190.162\"/>\n</g>\n<!-- asia -->\n<g id=\"node8\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"161.4971\" cy=\"-234\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"161.4971\" y=\"-230.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">asia</text>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M161.4971,-215.8314C161.4971,-208.131 161.4971,-198.9743 161.4971,-190.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"164.9972,-190.4132 161.4971,-180.4133 157.9972,-190.4133 164.9972,-190.4132\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            },
+            "text/plain": [
+              "'Digraph.gv.pdf'"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 9
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3s_MxAup4Ol2"
+      },
+      "source": [
+        "# Inference"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "dJwoaVgi47Oe"
+      },
+      "source": [
+        "from pgmpy.inference import VariableElimination\n",
+        "infer = VariableElimination(model)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "RENNeAKA9nbj"
+      },
+      "source": [
+        "def get_marginals(evidence = {}):\n",
+        "  nodes = model.nodes()\n",
+        "  num_nodes = len(nodes)\n",
+        "  marginals = dict()\n",
+        "  for n in nodes:\n",
+        "    if n in evidence: # observed nodes\n",
+        "      v = evidence[n]\n",
+        "      if v == 1:      \n",
+        "        marginals[n] = 1.0 # clamped to state 1\n",
+        "      else:\n",
+        "        marginals[n] = 0.0 # clamped to state 0\n",
+        "    else:\n",
+        "      probs = infer.query([n], evidence=evidence).values\n",
+        "      marginals[n] = probs[1] # probability in state 1\n",
+        "  return marginals\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "r1_t_YvN0XwF"
+      },
+      "source": [
+        "def visualization(marginals, model):\n",
+        "  h = Digraph('asia_net')\n",
+        "  titles = list(marginals.keys())\n",
+        "  yes_prob = list(marginals.values())\n",
+        "  no_prob = [1 - x for x in yes_prob]\n",
+        "  for i in range(len(marginals)):\n",
+        "    h.node(titles[i], label='''<<TABLE>\n",
+        "      <TR PORT=\"header\">\n",
+        "          <TD BGCOLOR=\"#d23939\" COLSPAN=\"2\"> {} </TD>\n",
+        "      </TR>\n",
+        "      <TR>\n",
+        "        <TD>yes</TD>\n",
+        "        <TD>{}</TD>\n",
+        "      </TR>\n",
+        "      <TR>\n",
+        "        <TD>no</TD>\n",
+        "        <TD>{}</TD>\n",
+        "      </TR>\n",
+        "    </TABLE>>'''.format(titles[i], yes_prob[i], no_prob[i]))\n",
+        "\n",
+        "  edges = (model.edges())\n",
+        "  for item in edges:\n",
+        "    edge = list(item)\n",
+        "    h.edge(edge[0], edge[1])\n",
+        "  \n",
+        "  return h\n"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Fo1Z_lqa4fnB"
+      },
+      "source": [
+        "## Prior marginals"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "wIj_U9mC-Q3M",
+        "outputId": "8b76e463-b156-400c-ea79-62cfe5f0a335"
+      },
+      "source": [
+        "marginals = get_marginals()\n",
+        "for k, v in marginals.items():\n",
+        "  print(k, v)\n",
+        "assert np.allclose(asia_prior_true, marginals['asia']) #Asia (0.5, 0.5)\n",
+        "h = visualization(marginals, model)\n",
+        "h"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1290.04it/s]\n",
+            "Eliminating: smoke: 100%|██████████| 7/7 [00:00<00:00, 228.41it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 2296.45it/s]\n",
+            "Eliminating: asia: 100%|██████████| 7/7 [00:00<00:00, 289.01it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 3465.96it/s]\n",
+            "Eliminating: asia: 100%|██████████| 7/7 [00:00<00:00, 275.86it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 3357.36it/s]\n",
+            "Eliminating: asia: 100%|██████████| 7/7 [00:00<00:00, 193.87it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 2754.23it/s]\n",
+            "Eliminating: asia: 100%|██████████| 7/7 [00:00<00:00, 218.06it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 3224.97it/s]\n",
+            "Eliminating: asia: 100%|██████████| 7/7 [00:00<00:00, 318.15it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 2813.35it/s]\n",
+            "Eliminating: asia: 100%|██████████| 7/7 [00:00<00:00, 226.37it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1081.01it/s]\n",
+            "Eliminating: asia: 100%|██████████| 7/7 [00:00<00:00, 220.88it/s]\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "asia 0.99\n",
+            "tub 0.9896\n",
+            "smoke 0.5\n",
+            "lung 0.9450000000000001\n",
+            "bronc 0.55\n",
+            "either 0.935172\n",
+            "xray 0.88970996\n",
+            "dysp 0.5640294\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7fa5dc7ea650>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: asia_net Pages: 1 -->\n<svg width=\"751pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 751.01 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>asia_net</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 747.0143,-570.2052 747.0143,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"142.8356\" cy=\"-508.9295\" rx=\"142.6713\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"52.8356,-520.9295 52.8356,-541.9295 232.8356,-541.9295 232.8356,-520.9295 52.8356,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"52.8356,-520.9295 52.8356,-541.9295 232.8356,-541.9295 232.8356,-520.9295 52.8356,-520.9295\"/>\n<text text-anchor=\"start\" x=\"128.3356\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"52.8356,-497.9295 52.8356,-518.9295 77.8356,-518.9295 77.8356,-497.9295 52.8356,-497.9295\"/>\n<text text-anchor=\"start\" x=\"55.8356\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"79.8356,-497.9295 79.8356,-518.9295 232.8356,-518.9295 232.8356,-497.9295 79.8356,-497.9295\"/>\n<text text-anchor=\"start\" x=\"142.8356\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.99</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"52.8356,-474.9295 52.8356,-495.9295 77.8356,-495.9295 77.8356,-474.9295 52.8356,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.3356\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"79.8356,-474.9295 79.8356,-495.9295 232.8356,-495.9295 232.8356,-474.9295 79.8356,-474.9295\"/>\n<text text-anchor=\"start\" x=\"82.8356\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.010000000000000009</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"49.8356,-472.4295 49.8356,-545.4295 235.8356,-545.4295 235.8356,-472.4295 49.8356,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"142.8356\" cy=\"-358.3782\" rx=\"142.6713\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"52.8356,-370.3782 52.8356,-391.3782 232.8356,-391.3782 232.8356,-370.3782 52.8356,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"52.8356,-370.3782 52.8356,-391.3782 232.8356,-391.3782 232.8356,-370.3782 52.8356,-370.3782\"/>\n<text text-anchor=\"start\" x=\"129.3356\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"52.8356,-347.3782 52.8356,-368.3782 77.8356,-368.3782 77.8356,-347.3782 52.8356,-347.3782\"/>\n<text text-anchor=\"start\" x=\"55.8356\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"79.8356,-347.3782 79.8356,-368.3782 232.8356,-368.3782 232.8356,-347.3782 79.8356,-347.3782\"/>\n<text text-anchor=\"start\" x=\"135.3356\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.9896</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"52.8356,-324.3782 52.8356,-345.3782 77.8356,-345.3782 77.8356,-324.3782 52.8356,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.3356\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"79.8356,-324.3782 79.8356,-345.3782 232.8356,-345.3782 232.8356,-324.3782 79.8356,-324.3782\"/>\n<text text-anchor=\"start\" x=\"82.8356\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.010399999999999965</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"49.8356,-321.8782 49.8356,-394.8782 235.8356,-394.8782 235.8356,-321.8782 49.8356,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M142.8356,-451.5831C142.8356,-443.3123 142.8356,-434.7349 142.8356,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"146.3357,-426.064 142.8356,-416.064 139.3357,-426.064 146.3357,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"368.8356\" cy=\"-207.8269\" rx=\"79.3924\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"323.8356,-219.8269 323.8356,-240.8269 413.8356,-240.8269 413.8356,-219.8269 323.8356,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"323.8356,-219.8269 323.8356,-240.8269 413.8356,-240.8269 413.8356,-219.8269 323.8356,-219.8269\"/>\n<text text-anchor=\"start\" x=\"348.8356\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"323.8356,-196.8269 323.8356,-217.8269 348.8356,-217.8269 348.8356,-196.8269 323.8356,-196.8269\"/>\n<text text-anchor=\"start\" x=\"326.8356\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"350.8356,-196.8269 350.8356,-217.8269 413.8356,-217.8269 413.8356,-196.8269 350.8356,-196.8269\"/>\n<text text-anchor=\"start\" x=\"353.8356\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.935172</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"323.8356,-173.8269 323.8356,-194.8269 348.8356,-194.8269 348.8356,-173.8269 323.8356,-173.8269\"/>\n<text text-anchor=\"start\" x=\"328.3356\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"350.8356,-173.8269 350.8356,-194.8269 413.8356,-194.8269 413.8356,-173.8269 350.8356,-173.8269\"/>\n<text text-anchor=\"start\" x=\"353.8356\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.064828</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"320.8356,-171.3269 320.8356,-244.3269 416.8356,-244.3269 416.8356,-171.3269 320.8356,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M216.5237,-309.2904C243.9544,-291.0173 274.9158,-270.3922 301.7255,-252.5327\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"303.8924,-255.2948 310.2744,-246.8378 300.0115,-249.4691 303.8924,-255.2948\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"522.8356\" cy=\"-508.9295\" rx=\"53.9813\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"495.8356,-520.9295 495.8356,-541.9295 549.8356,-541.9295 549.8356,-520.9295 495.8356,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"495.8356,-520.9295 495.8356,-541.9295 549.8356,-541.9295 549.8356,-520.9295 495.8356,-520.9295\"/>\n<text text-anchor=\"start\" x=\"499.8356\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"495.8356,-497.9295 495.8356,-518.9295 521.8356,-518.9295 521.8356,-497.9295 495.8356,-497.9295\"/>\n<text text-anchor=\"start\" x=\"499.3356\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"523.8356,-497.9295 523.8356,-518.9295 549.8356,-518.9295 549.8356,-497.9295 523.8356,-497.9295\"/>\n<text text-anchor=\"start\" x=\"527.3356\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.5</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"495.8356,-474.9295 495.8356,-495.9295 521.8356,-495.9295 521.8356,-474.9295 495.8356,-474.9295\"/>\n<text text-anchor=\"start\" x=\"500.8356\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"523.8356,-474.9295 523.8356,-495.9295 549.8356,-495.9295 549.8356,-474.9295 523.8356,-474.9295\"/>\n<text text-anchor=\"start\" x=\"527.3356\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.5</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"492.8356,-472.4295 492.8356,-545.4295 552.8356,-545.4295 552.8356,-472.4295 492.8356,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"440.8356\" cy=\"-358.3782\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"354.8356,-370.3782 354.8356,-391.3782 526.8356,-391.3782 526.8356,-370.3782 354.8356,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"354.8356,-370.3782 354.8356,-391.3782 526.8356,-391.3782 526.8356,-370.3782 354.8356,-370.3782\"/>\n<text text-anchor=\"start\" x=\"423.8356\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"354.8356,-347.3782 354.8356,-368.3782 379.8356,-368.3782 379.8356,-347.3782 354.8356,-347.3782\"/>\n<text text-anchor=\"start\" x=\"357.8356\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"381.8356,-347.3782 381.8356,-368.3782 526.8356,-368.3782 526.8356,-347.3782 381.8356,-347.3782\"/>\n<text text-anchor=\"start\" x=\"388.3356\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.9450000000000001</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"354.8356,-324.3782 354.8356,-345.3782 379.8356,-345.3782 379.8356,-324.3782 354.8356,-324.3782\"/>\n<text text-anchor=\"start\" x=\"359.3356\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"381.8356,-324.3782 381.8356,-345.3782 526.8356,-345.3782 526.8356,-324.3782 381.8356,-324.3782\"/>\n<text text-anchor=\"start\" x=\"384.8356\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.05499999999999994</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"351.8356,-321.8782 351.8356,-394.8782 529.8356,-394.8782 529.8356,-321.8782 351.8356,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M495.7584,-459.2162C489.5132,-447.7499 482.7789,-435.3858 476.2382,-423.3772\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"479.1425,-421.392 471.2856,-414.2842 472.9951,-424.7402 479.1425,-421.392\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"605.8356\" cy=\"-207.8269\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"519.8356,-219.8269 519.8356,-240.8269 691.8356,-240.8269 691.8356,-219.8269 519.8356,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"519.8356,-219.8269 519.8356,-240.8269 691.8356,-240.8269 691.8356,-219.8269 519.8356,-219.8269\"/>\n<text text-anchor=\"start\" x=\"585.3356\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"519.8356,-196.8269 519.8356,-217.8269 544.8356,-217.8269 544.8356,-196.8269 519.8356,-196.8269\"/>\n<text text-anchor=\"start\" x=\"522.8356\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"546.8356,-196.8269 546.8356,-217.8269 691.8356,-217.8269 691.8356,-196.8269 546.8356,-196.8269\"/>\n<text text-anchor=\"start\" x=\"605.8356\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.55</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"519.8356,-173.8269 519.8356,-194.8269 544.8356,-194.8269 544.8356,-173.8269 519.8356,-173.8269\"/>\n<text text-anchor=\"start\" x=\"524.3356\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"546.8356,-173.8269 546.8356,-194.8269 691.8356,-194.8269 691.8356,-173.8269 546.8356,-173.8269\"/>\n<text text-anchor=\"start\" x=\"549.8356\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.44999999999999996</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"516.8356,-171.3269 516.8356,-244.3269 694.8356,-244.3269 694.8356,-171.3269 516.8356,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M559.0872,-465.9495C569.8373,-450.9389 580.4369,-433.3884 586.8356,-415.6539 603.0234,-370.7877 607.5868,-317.1071 608.2005,-275.5421\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"611.7004,-275.5457 608.276,-265.5196 604.7006,-275.4929 611.7004,-275.5457\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M413.8206,-301.8902C409.0547,-291.9247 404.0643,-281.4899 399.2136,-271.3471\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"402.2805,-269.6476 394.8086,-262.1362 395.9655,-272.6677 402.2805,-269.6476\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"605.8356\" cy=\"-57.2756\" rx=\"84.2917\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"557.8356,-69.2756 557.8356,-90.2756 654.8356,-90.2756 654.8356,-69.2756 557.8356,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"557.8356,-69.2756 557.8356,-90.2756 654.8356,-90.2756 654.8356,-69.2756 557.8356,-69.2756\"/>\n<text text-anchor=\"start\" x=\"588.3356\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"557.8356,-46.2756 557.8356,-67.2756 582.8356,-67.2756 582.8356,-46.2756 557.8356,-46.2756\"/>\n<text text-anchor=\"start\" x=\"560.8356\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"584.8356,-46.2756 584.8356,-67.2756 654.8356,-67.2756 654.8356,-46.2756 584.8356,-46.2756\"/>\n<text text-anchor=\"start\" x=\"587.8356\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.5640294</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"557.8356,-23.2756 557.8356,-44.2756 582.8356,-44.2756 582.8356,-23.2756 557.8356,-23.2756\"/>\n<text text-anchor=\"start\" x=\"562.3356\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"584.8356,-23.2756 584.8356,-44.2756 654.8356,-44.2756 654.8356,-23.2756 584.8356,-23.2756\"/>\n<text text-anchor=\"start\" x=\"587.8356\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.4359706</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"554.3356,-20.7756 554.3356,-93.7756 657.3356,-93.7756 657.3356,-20.7756 554.3356,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M605.8356,-150.4805C605.8356,-142.2097 605.8356,-133.6324 605.8356,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"609.3357,-124.9614 605.8356,-114.9614 602.3357,-124.9614 609.3357,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"366.8356\" cy=\"-57.2756\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"280.8356,-69.2756 280.8356,-90.2756 452.8356,-90.2756 452.8356,-69.2756 280.8356,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"280.8356,-69.2756 280.8356,-90.2756 452.8356,-90.2756 452.8356,-69.2756 280.8356,-69.2756\"/>\n<text text-anchor=\"start\" x=\"349.8356\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"280.8356,-46.2756 280.8356,-67.2756 305.8356,-67.2756 305.8356,-46.2756 280.8356,-46.2756\"/>\n<text text-anchor=\"start\" x=\"283.8356\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"307.8356,-46.2756 307.8356,-67.2756 452.8356,-67.2756 452.8356,-46.2756 307.8356,-46.2756\"/>\n<text text-anchor=\"start\" x=\"344.3356\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.88970996</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"280.8356,-23.2756 280.8356,-44.2756 305.8356,-44.2756 305.8356,-23.2756 280.8356,-23.2756\"/>\n<text text-anchor=\"start\" x=\"285.3356\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"307.8356,-23.2756 307.8356,-44.2756 452.8356,-44.2756 452.8356,-23.2756 307.8356,-23.2756\"/>\n<text text-anchor=\"start\" x=\"310.8356\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.11029003999999998</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"277.8356,-20.7756 277.8356,-93.7756 455.8356,-93.7756 455.8356,-20.7756 277.8356,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M368.0738,-150.4805C367.9639,-142.2097 367.8499,-133.6324 367.7376,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"371.2345,-124.914 367.6019,-114.9614 364.2351,-125.007 371.2345,-124.914\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M428.6407,-169.8365C461.1292,-149.1986 501.4925,-123.5583 535.486,-101.9643\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"537.4183,-104.8834 543.9825,-96.567 533.6648,-98.9748 537.4183,-104.8834\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 35
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "StB-XG1z7FEP"
+      },
+      "source": [
+        "## Posterior marginals given dsypnea=present"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "ZMcpy_pA67bi",
+        "outputId": "c33a2425-5d7c-41b5-a568-313921fd6f27"
+      },
+      "source": [
+        "evidence  = {'dysp': 0}\n",
+        "marginals = get_marginals(evidence)\n",
+        "print('\\n')\n",
+        "for k, v in marginals.items():\n",
+        "  print(k, v)\n",
+        "h = visualization(marginals, model)\n",
+        "h"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/pgmpy/factors/discrete/DiscreteFactor.py:519: UserWarning: Found unknown state name. Trying to switch to using all state names as state numbers\n",
+            "  \"Found unknown state name. Trying to switch to using all state names as state numbers\"\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 863.20it/s]\n",
+            "Eliminating: smoke: 100%|██████████| 6/6 [00:00<00:00, 248.90it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 949.40it/s]\n",
+            "Eliminating: asia: 100%|██████████| 6/6 [00:00<00:00, 251.02it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 889.82it/s]\n",
+            "Eliminating: asia: 100%|██████████| 6/6 [00:00<00:00, 281.07it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 2096.10it/s]\n",
+            "Eliminating: asia: 100%|██████████| 6/6 [00:00<00:00, 294.52it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 808.15it/s]\n",
+            "Eliminating: asia: 100%|██████████| 6/6 [00:00<00:00, 251.01it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1578.09it/s]\n",
+            "Eliminating: asia: 100%|██████████| 6/6 [00:00<00:00, 252.96it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 2619.80it/s]\n",
+            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 261.27it/s]\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "asia 0.9896750491890968\n",
+            "tub 0.9811546925411943\n",
+            "smoke 0.36600312039389815\n",
+            "lung 0.8972407772450711\n",
+            "bronc 0.16603266367044014\n",
+            "either 0.8794641657029166\n",
+            "xray 0.8379016741037125\n",
+            "dysp 0.0\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7fa5dc7bee90>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: asia_net Pages: 1 -->\n<svg width=\"745pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 745.01 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>asia_net</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 741.0143,-570.2052 741.0143,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"142.8356\" cy=\"-508.9295\" rx=\"142.6713\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"52.8356,-520.9295 52.8356,-541.9295 232.8356,-541.9295 232.8356,-520.9295 52.8356,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"52.8356,-520.9295 52.8356,-541.9295 232.8356,-541.9295 232.8356,-520.9295 52.8356,-520.9295\"/>\n<text text-anchor=\"start\" x=\"128.3356\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"52.8356,-497.9295 52.8356,-518.9295 77.8356,-518.9295 77.8356,-497.9295 52.8356,-497.9295\"/>\n<text text-anchor=\"start\" x=\"55.8356\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"79.8356,-497.9295 79.8356,-518.9295 232.8356,-518.9295 232.8356,-497.9295 79.8356,-497.9295\"/>\n<text text-anchor=\"start\" x=\"90.3356\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.9896750491890968</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"52.8356,-474.9295 52.8356,-495.9295 77.8356,-495.9295 77.8356,-474.9295 52.8356,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.3356\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"79.8356,-474.9295 79.8356,-495.9295 232.8356,-495.9295 232.8356,-474.9295 79.8356,-474.9295\"/>\n<text text-anchor=\"start\" x=\"82.8356\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.010324950810903233</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"49.8356,-472.4295 49.8356,-545.4295 235.8356,-545.4295 235.8356,-472.4295 49.8356,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"142.8356\" cy=\"-358.3782\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"56.8356,-370.3782 56.8356,-391.3782 228.8356,-391.3782 228.8356,-370.3782 56.8356,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"56.8356,-370.3782 56.8356,-391.3782 228.8356,-391.3782 228.8356,-370.3782 56.8356,-370.3782\"/>\n<text text-anchor=\"start\" x=\"129.3356\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"56.8356,-347.3782 56.8356,-368.3782 81.8356,-368.3782 81.8356,-347.3782 56.8356,-347.3782\"/>\n<text text-anchor=\"start\" x=\"59.8356\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"83.8356,-347.3782 83.8356,-368.3782 228.8356,-368.3782 228.8356,-347.3782 83.8356,-347.3782\"/>\n<text text-anchor=\"start\" x=\"91.3356\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.9811546925411943</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"56.8356,-324.3782 56.8356,-345.3782 81.8356,-345.3782 81.8356,-324.3782 56.8356,-324.3782\"/>\n<text text-anchor=\"start\" x=\"61.3356\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"83.8356,-324.3782 83.8356,-345.3782 228.8356,-345.3782 228.8356,-324.3782 83.8356,-324.3782\"/>\n<text text-anchor=\"start\" x=\"86.8356\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.01884530745880575</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"53.8356,-321.8782 53.8356,-394.8782 231.8356,-394.8782 231.8356,-321.8782 53.8356,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M142.8356,-451.5831C142.8356,-443.3123 142.8356,-434.7349 142.8356,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"146.3357,-426.064 142.8356,-416.064 139.3357,-426.064 146.3357,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"307.8356\" cy=\"-207.8269\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"221.8356,-219.8269 221.8356,-240.8269 393.8356,-240.8269 393.8356,-219.8269 221.8356,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"221.8356,-219.8269 221.8356,-240.8269 393.8356,-240.8269 393.8356,-219.8269 221.8356,-219.8269\"/>\n<text text-anchor=\"start\" x=\"287.8356\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"221.8356,-196.8269 221.8356,-217.8269 246.8356,-217.8269 246.8356,-196.8269 221.8356,-196.8269\"/>\n<text text-anchor=\"start\" x=\"224.8356\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"248.8356,-196.8269 248.8356,-217.8269 393.8356,-217.8269 393.8356,-196.8269 248.8356,-196.8269\"/>\n<text text-anchor=\"start\" x=\"255.3356\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.8794641657029166</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"221.8356,-173.8269 221.8356,-194.8269 246.8356,-194.8269 246.8356,-173.8269 221.8356,-173.8269\"/>\n<text text-anchor=\"start\" x=\"226.3356\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"248.8356,-173.8269 248.8356,-194.8269 393.8356,-194.8269 393.8356,-173.8269 248.8356,-173.8269\"/>\n<text text-anchor=\"start\" x=\"251.8356\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.12053583429708337</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"218.8356,-171.3269 218.8356,-244.3269 396.8356,-244.3269 396.8356,-171.3269 218.8356,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M200.0815,-306.1452C213.9036,-293.5335 228.7723,-279.9668 242.9179,-267.06\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"245.6628,-269.2934 250.6908,-259.9676 240.9446,-264.1224 245.6628,-269.2934\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"519.8356\" cy=\"-508.9295\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"433.8356,-520.9295 433.8356,-541.9295 605.8356,-541.9295 605.8356,-520.9295 433.8356,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"433.8356,-520.9295 433.8356,-541.9295 605.8356,-541.9295 605.8356,-520.9295 433.8356,-520.9295\"/>\n<text text-anchor=\"start\" x=\"496.8356\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"433.8356,-497.9295 433.8356,-518.9295 458.8356,-518.9295 458.8356,-497.9295 433.8356,-497.9295\"/>\n<text text-anchor=\"start\" x=\"436.8356\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"460.8356,-497.9295 460.8356,-518.9295 605.8356,-518.9295 605.8356,-497.9295 460.8356,-497.9295\"/>\n<text text-anchor=\"start\" x=\"463.8356\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.36600312039389815</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"433.8356,-474.9295 433.8356,-495.9295 458.8356,-495.9295 458.8356,-474.9295 433.8356,-474.9295\"/>\n<text text-anchor=\"start\" x=\"438.3356\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"460.8356,-474.9295 460.8356,-495.9295 605.8356,-495.9295 605.8356,-474.9295 460.8356,-474.9295\"/>\n<text text-anchor=\"start\" x=\"467.3356\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.6339968796061018</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"430.8356,-472.4295 430.8356,-545.4295 608.8356,-545.4295 608.8356,-472.4295 430.8356,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"434.8356\" cy=\"-358.3782\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"348.8356,-370.3782 348.8356,-391.3782 520.8356,-391.3782 520.8356,-370.3782 348.8356,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"348.8356,-370.3782 348.8356,-391.3782 520.8356,-391.3782 520.8356,-370.3782 348.8356,-370.3782\"/>\n<text text-anchor=\"start\" x=\"417.8356\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"348.8356,-347.3782 348.8356,-368.3782 373.8356,-368.3782 373.8356,-347.3782 348.8356,-347.3782\"/>\n<text text-anchor=\"start\" x=\"351.8356\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"375.8356,-347.3782 375.8356,-368.3782 520.8356,-368.3782 520.8356,-347.3782 375.8356,-347.3782\"/>\n<text text-anchor=\"start\" x=\"382.8356\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.8972407772450711</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"348.8356,-324.3782 348.8356,-345.3782 373.8356,-345.3782 373.8356,-324.3782 348.8356,-324.3782\"/>\n<text text-anchor=\"start\" x=\"353.3356\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"375.8356,-324.3782 375.8356,-345.3782 520.8356,-345.3782 520.8356,-324.3782 375.8356,-324.3782\"/>\n<text text-anchor=\"start\" x=\"378.8356\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.10275922275492888</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"345.8356,-321.8782 345.8356,-394.8782 523.8356,-394.8782 523.8356,-321.8782 345.8356,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M488.1847,-452.8698C482.7279,-443.2047 477.0153,-433.0867 471.4407,-423.213\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"474.3356,-421.2213 466.3713,-414.2341 468.24,-424.6628 474.3356,-421.2213\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"599.8356\" cy=\"-207.8269\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"513.8356,-219.8269 513.8356,-240.8269 685.8356,-240.8269 685.8356,-219.8269 513.8356,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"513.8356,-219.8269 513.8356,-240.8269 685.8356,-240.8269 685.8356,-219.8269 513.8356,-219.8269\"/>\n<text text-anchor=\"start\" x=\"579.3356\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"513.8356,-196.8269 513.8356,-217.8269 538.8356,-217.8269 538.8356,-196.8269 513.8356,-196.8269\"/>\n<text text-anchor=\"start\" x=\"516.8356\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"540.8356,-196.8269 540.8356,-217.8269 685.8356,-217.8269 685.8356,-196.8269 540.8356,-196.8269\"/>\n<text text-anchor=\"start\" x=\"543.8356\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.16603266367044014</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"513.8356,-173.8269 513.8356,-194.8269 538.8356,-194.8269 538.8356,-173.8269 513.8356,-173.8269\"/>\n<text text-anchor=\"start\" x=\"518.3356\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"540.8356,-173.8269 540.8356,-194.8269 685.8356,-194.8269 685.8356,-173.8269 540.8356,-173.8269\"/>\n<text text-anchor=\"start\" x=\"547.3356\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.8339673363295599</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"510.8356,-171.3269 510.8356,-244.3269 688.8356,-244.3269 688.8356,-171.3269 510.8356,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M561.817,-454.2795C569.3282,-442.1266 576.2213,-428.9014 580.8356,-415.6539 596.5245,-370.6108 601.102,-316.9353 601.8473,-275.4169\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"605.3471,-275.4446 601.9575,-265.4066 598.3475,-275.3675 605.3471,-275.4446\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M388.9857,-304.0258C379.6337,-292.9396 369.7269,-281.1956 360.1687,-269.8649\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"362.7414,-267.4865 353.6182,-262.0996 357.3908,-272 362.7414,-267.4865\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"557.8356\" cy=\"-57.2756\" rx=\"52.1524\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"531.8356,-69.2756 531.8356,-90.2756 583.8356,-90.2756 583.8356,-69.2756 531.8356,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"531.8356,-69.2756 531.8356,-90.2756 583.8356,-90.2756 583.8356,-69.2756 531.8356,-69.2756\"/>\n<text text-anchor=\"start\" x=\"539.8356\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"531.8356,-46.2756 531.8356,-67.2756 556.8356,-67.2756 556.8356,-46.2756 531.8356,-46.2756\"/>\n<text text-anchor=\"start\" x=\"534.8356\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"558.8356,-46.2756 558.8356,-67.2756 583.8356,-67.2756 583.8356,-46.2756 558.8356,-46.2756\"/>\n<text text-anchor=\"start\" x=\"561.8356\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.0</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"531.8356,-23.2756 531.8356,-44.2756 556.8356,-44.2756 556.8356,-23.2756 531.8356,-23.2756\"/>\n<text text-anchor=\"start\" x=\"536.3356\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"558.8356,-23.2756 558.8356,-44.2756 583.8356,-44.2756 583.8356,-23.2756 558.8356,-23.2756\"/>\n<text text-anchor=\"start\" x=\"561.8356\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.0</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"528.8356,-20.7756 528.8356,-93.7756 586.8356,-93.7756 586.8356,-20.7756 528.8356,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M583.9572,-150.91C581.3366,-141.5162 578.6026,-131.7163 575.9325,-122.1452\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"579.239,-120.9722 573.1805,-112.2805 572.4965,-122.8532 579.239,-120.9722\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"307.8356\" cy=\"-57.2756\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"221.8356,-69.2756 221.8356,-90.2756 393.8356,-90.2756 393.8356,-69.2756 221.8356,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"221.8356,-69.2756 221.8356,-90.2756 393.8356,-90.2756 393.8356,-69.2756 221.8356,-69.2756\"/>\n<text text-anchor=\"start\" x=\"290.8356\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"221.8356,-46.2756 221.8356,-67.2756 246.8356,-67.2756 246.8356,-46.2756 221.8356,-46.2756\"/>\n<text text-anchor=\"start\" x=\"224.8356\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"248.8356,-46.2756 248.8356,-67.2756 393.8356,-67.2756 393.8356,-46.2756 248.8356,-46.2756\"/>\n<text text-anchor=\"start\" x=\"255.3356\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.8379016741037125</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"221.8356,-23.2756 221.8356,-44.2756 246.8356,-44.2756 246.8356,-23.2756 221.8356,-23.2756\"/>\n<text text-anchor=\"start\" x=\"226.3356\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"248.8356,-23.2756 248.8356,-44.2756 393.8356,-44.2756 393.8356,-23.2756 248.8356,-23.2756\"/>\n<text text-anchor=\"start\" x=\"251.8356\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.16209832589628748</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"218.8356,-20.7756 218.8356,-93.7756 396.8356,-93.7756 396.8356,-20.7756 218.8356,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M307.8356,-150.4805C307.8356,-142.2097 307.8356,-133.6324 307.8356,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"311.3357,-124.9614 307.8356,-114.9614 304.3357,-124.9614 311.3357,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M386.2512,-160.6046C424.1089,-137.8066 468.6191,-111.0023 502.8178,-90.4076\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"504.9658,-93.1998 511.7268,-85.0426 501.3546,-87.2032 504.9658,-93.1998\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 36
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4xM1w8qR8wgG"
+      },
+      "source": [
+        "## Posterior marginals given dsypnea=present, asia=visit"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "eJJhZFWf70pl",
+        "outputId": "7e81d264-3be9-4539-b7b4-a5c4b78fa529"
+      },
+      "source": [
+        "evidence  = {'dysp': 0, 'asia': 0}\n",
+        "marginals = get_marginals(evidence)\n",
+        "print('\\n')\n",
+        "for k, v in marginals.items():\n",
+        "  print(k, v)\n",
+        "h = visualization(marginals, model)\n",
+        "h"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/pgmpy/factors/discrete/DiscreteFactor.py:519: UserWarning: Found unknown state name. Trying to switch to using all state names as state numbers\n",
+            "  \"Found unknown state name. Trying to switch to using all state names as state numbers\"\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1036.45it/s]\n",
+            "Eliminating: smoke: 100%|██████████| 5/5 [00:00<00:00, 239.88it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1649.87it/s]\n",
+            "Eliminating: lung: 100%|██████████| 5/5 [00:00<00:00, 198.64it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 2478.32it/s]\n",
+            "Eliminating: smoke: 100%|██████████| 5/5 [00:00<00:00, 189.35it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 788.43it/s]\n",
+            "Eliminating: smoke: 100%|██████████| 5/5 [00:00<00:00, 216.34it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 786.63it/s]\n",
+            "Eliminating: smoke: 100%|██████████| 5/5 [00:00<00:00, 164.87it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 830.72it/s]\n",
+            "Eliminating: either: 100%|██████████| 5/5 [00:00<00:00, 307.02it/s]\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "asia 0.0\n",
+            "tub 0.9122490350170781\n",
+            "smoke 0.3740801421787786\n",
+            "lung 0.9004748549054455\n",
+            "bronc 0.1885979284107634\n",
+            "either 0.8177001471772514\n",
+            "xray 0.7804611368748438\n",
+            "dysp 0.0\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7fa5dd047d90>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: asia_net Pages: 1 -->\n<svg width=\"724pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 724.46 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>asia_net</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 720.4579,-570.2052 720.4579,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"132.229\" cy=\"-508.9295\" rx=\"52.1524\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"106.229,-520.9295 106.229,-541.9295 158.229,-541.9295 158.229,-520.9295 106.229,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"106.229,-520.9295 106.229,-541.9295 158.229,-541.9295 158.229,-520.9295 106.229,-520.9295\"/>\n<text text-anchor=\"start\" x=\"117.729\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"106.229,-497.9295 106.229,-518.9295 131.229,-518.9295 131.229,-497.9295 106.229,-497.9295\"/>\n<text text-anchor=\"start\" x=\"109.229\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"133.229,-497.9295 133.229,-518.9295 158.229,-518.9295 158.229,-497.9295 133.229,-497.9295\"/>\n<text text-anchor=\"start\" x=\"136.229\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.0</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"106.229,-474.9295 106.229,-495.9295 131.229,-495.9295 131.229,-474.9295 106.229,-474.9295\"/>\n<text text-anchor=\"start\" x=\"110.729\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"133.229,-474.9295 133.229,-495.9295 158.229,-495.9295 158.229,-474.9295 133.229,-474.9295\"/>\n<text text-anchor=\"start\" x=\"136.229\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.0</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"103.229,-472.4295 103.229,-545.4295 161.229,-545.4295 161.229,-472.4295 103.229,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"132.229\" cy=\"-358.3782\" rx=\"132.4583\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"50.229,-370.3782 50.229,-391.3782 215.229,-391.3782 215.229,-370.3782 50.229,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"50.229,-370.3782 50.229,-391.3782 215.229,-391.3782 215.229,-370.3782 50.229,-370.3782\"/>\n<text text-anchor=\"start\" x=\"119.229\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"50.229,-347.3782 50.229,-368.3782 75.229,-368.3782 75.229,-347.3782 50.229,-347.3782\"/>\n<text text-anchor=\"start\" x=\"53.229\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"77.229,-347.3782 77.229,-368.3782 215.229,-368.3782 215.229,-347.3782 77.229,-347.3782\"/>\n<text text-anchor=\"start\" x=\"80.229\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.9122490350170781</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"50.229,-324.3782 50.229,-345.3782 75.229,-345.3782 75.229,-324.3782 50.229,-324.3782\"/>\n<text text-anchor=\"start\" x=\"54.729\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"77.229,-324.3782 77.229,-345.3782 215.229,-345.3782 215.229,-324.3782 77.229,-324.3782\"/>\n<text text-anchor=\"start\" x=\"80.229\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.0877509649829219</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"46.729,-321.8782 46.729,-394.8782 217.729,-394.8782 217.729,-321.8782 46.729,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M132.229,-451.5831C132.229,-443.3123 132.229,-434.7349 132.229,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"135.7291,-426.064 132.229,-416.064 128.7291,-426.064 135.7291,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"297.229\" cy=\"-207.8269\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"211.229,-219.8269 211.229,-240.8269 383.229,-240.8269 383.229,-219.8269 211.229,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"211.229,-219.8269 211.229,-240.8269 383.229,-240.8269 383.229,-219.8269 211.229,-219.8269\"/>\n<text text-anchor=\"start\" x=\"277.229\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"211.229,-196.8269 211.229,-217.8269 236.229,-217.8269 236.229,-196.8269 211.229,-196.8269\"/>\n<text text-anchor=\"start\" x=\"214.229\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"238.229,-196.8269 238.229,-217.8269 383.229,-217.8269 383.229,-196.8269 238.229,-196.8269\"/>\n<text text-anchor=\"start\" x=\"244.729\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.8177001471772514</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"211.229,-173.8269 211.229,-194.8269 236.229,-194.8269 236.229,-173.8269 211.229,-173.8269\"/>\n<text text-anchor=\"start\" x=\"215.729\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"238.229,-173.8269 238.229,-194.8269 383.229,-194.8269 383.229,-173.8269 238.229,-173.8269\"/>\n<text text-anchor=\"start\" x=\"241.229\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.18229985282274863</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"208.229,-171.3269 208.229,-244.3269 386.229,-244.3269 386.229,-171.3269 208.229,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M189.0126,-306.567C203.0633,-293.7467 218.2198,-279.9174 232.6133,-266.7843\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.0327,-269.3148 240.0607,-259.9891 230.3145,-264.1438 235.0327,-269.3148\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"501.229\" cy=\"-508.9295\" rx=\"132.4583\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"419.229,-520.9295 419.229,-541.9295 584.229,-541.9295 584.229,-520.9295 419.229,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"419.229,-520.9295 419.229,-541.9295 584.229,-541.9295 584.229,-520.9295 419.229,-520.9295\"/>\n<text text-anchor=\"start\" x=\"478.729\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"419.229,-497.9295 419.229,-518.9295 444.229,-518.9295 444.229,-497.9295 419.229,-497.9295\"/>\n<text text-anchor=\"start\" x=\"422.229\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"446.229,-497.9295 446.229,-518.9295 584.229,-518.9295 584.229,-497.9295 446.229,-497.9295\"/>\n<text text-anchor=\"start\" x=\"449.229\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.3740801421787786</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"419.229,-474.9295 419.229,-495.9295 444.229,-495.9295 444.229,-474.9295 419.229,-474.9295\"/>\n<text text-anchor=\"start\" x=\"423.729\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"446.229,-474.9295 446.229,-495.9295 584.229,-495.9295 584.229,-474.9295 446.229,-474.9295\"/>\n<text text-anchor=\"start\" x=\"449.229\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.6259198578212214</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"415.729,-472.4295 415.729,-545.4295 586.729,-545.4295 586.729,-472.4295 415.729,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"419.229\" cy=\"-358.3782\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"333.229,-370.3782 333.229,-391.3782 505.229,-391.3782 505.229,-370.3782 333.229,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"333.229,-370.3782 333.229,-391.3782 505.229,-391.3782 505.229,-370.3782 333.229,-370.3782\"/>\n<text text-anchor=\"start\" x=\"402.229\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"333.229,-347.3782 333.229,-368.3782 358.229,-368.3782 358.229,-347.3782 333.229,-347.3782\"/>\n<text text-anchor=\"start\" x=\"336.229\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"360.229,-347.3782 360.229,-368.3782 505.229,-368.3782 505.229,-347.3782 360.229,-347.3782\"/>\n<text text-anchor=\"start\" x=\"366.729\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.9004748549054455</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"333.229,-324.3782 333.229,-345.3782 358.229,-345.3782 358.229,-324.3782 333.229,-324.3782\"/>\n<text text-anchor=\"start\" x=\"337.729\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"360.229,-324.3782 360.229,-345.3782 505.229,-345.3782 505.229,-324.3782 360.229,-324.3782\"/>\n<text text-anchor=\"start\" x=\"363.229\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.09952514509455446</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"330.229,-321.8782 330.229,-394.8782 508.229,-394.8782 508.229,-321.8782 330.229,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M470.6952,-452.8698C465.431,-443.2047 459.92,-433.0867 454.5422,-423.213\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"457.5086,-421.3418 449.6517,-414.2341 451.3612,-424.6901 457.5086,-421.3418\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"584.229\" cy=\"-207.8269\" rx=\"132.4583\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"502.229,-219.8269 502.229,-240.8269 667.229,-240.8269 667.229,-219.8269 502.229,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"502.229,-219.8269 502.229,-240.8269 667.229,-240.8269 667.229,-219.8269 502.229,-219.8269\"/>\n<text text-anchor=\"start\" x=\"564.229\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"502.229,-196.8269 502.229,-217.8269 527.229,-217.8269 527.229,-196.8269 502.229,-196.8269\"/>\n<text text-anchor=\"start\" x=\"505.229\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"529.229,-196.8269 529.229,-217.8269 667.229,-217.8269 667.229,-196.8269 529.229,-196.8269\"/>\n<text text-anchor=\"start\" x=\"532.229\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.1885979284107634</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"502.229,-173.8269 502.229,-194.8269 527.229,-194.8269 527.229,-173.8269 502.229,-173.8269\"/>\n<text text-anchor=\"start\" x=\"506.729\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"529.229,-173.8269 529.229,-194.8269 667.229,-194.8269 667.229,-173.8269 529.229,-173.8269\"/>\n<text text-anchor=\"start\" x=\"532.729\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.8114020715892366</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"498.729,-171.3269 498.729,-244.3269 669.729,-244.3269 669.729,-171.3269 498.729,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M545.1256,-454.7556C553.0685,-442.5187 560.3633,-429.1395 565.229,-415.6539 581.4168,-370.7877 585.9802,-317.1071 586.5939,-275.5421\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"590.0938,-275.5457 586.6694,-265.5196 583.094,-275.4929 590.0938,-275.5457\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M375.1842,-304.0258C366.2868,-293.0461 356.8666,-281.4214 347.7667,-270.1918\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"350.2243,-267.6654 341.2091,-262.0996 344.7858,-272.0725 350.2243,-267.6654\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"544.229\" cy=\"-57.2756\" rx=\"52.1524\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"518.229,-69.2756 518.229,-90.2756 570.229,-90.2756 570.229,-69.2756 518.229,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"518.229,-69.2756 518.229,-90.2756 570.229,-90.2756 570.229,-69.2756 518.229,-69.2756\"/>\n<text text-anchor=\"start\" x=\"526.229\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"518.229,-46.2756 518.229,-67.2756 543.229,-67.2756 543.229,-46.2756 518.229,-46.2756\"/>\n<text text-anchor=\"start\" x=\"521.229\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"545.229,-46.2756 545.229,-67.2756 570.229,-67.2756 570.229,-46.2756 545.229,-46.2756\"/>\n<text text-anchor=\"start\" x=\"548.229\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.0</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"518.229,-23.2756 518.229,-44.2756 543.229,-44.2756 543.229,-23.2756 518.229,-23.2756\"/>\n<text text-anchor=\"start\" x=\"522.729\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"545.229,-23.2756 545.229,-44.2756 570.229,-44.2756 570.229,-23.2756 545.229,-23.2756\"/>\n<text text-anchor=\"start\" x=\"548.229\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.0</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"515.229,-20.7756 515.229,-93.7756 573.229,-93.7756 573.229,-20.7756 515.229,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M569.1067,-150.91C566.6109,-141.5162 564.0071,-131.7163 561.4642,-122.1452\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"564.7938,-121.0465 558.8432,-112.2805 558.0285,-122.844 564.7938,-121.0465\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"297.229\" cy=\"-57.2756\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"211.229,-69.2756 211.229,-90.2756 383.229,-90.2756 383.229,-69.2756 211.229,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"211.229,-69.2756 211.229,-90.2756 383.229,-90.2756 383.229,-69.2756 211.229,-69.2756\"/>\n<text text-anchor=\"start\" x=\"280.229\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"211.229,-46.2756 211.229,-67.2756 236.229,-67.2756 236.229,-46.2756 211.229,-46.2756\"/>\n<text text-anchor=\"start\" x=\"214.229\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"238.229,-46.2756 238.229,-67.2756 383.229,-67.2756 383.229,-46.2756 238.229,-46.2756\"/>\n<text text-anchor=\"start\" x=\"245.229\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.7804611368748438</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"211.229,-23.2756 211.229,-44.2756 236.229,-44.2756 236.229,-23.2756 211.229,-23.2756\"/>\n<text text-anchor=\"start\" x=\"215.729\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"238.229,-23.2756 238.229,-44.2756 383.229,-44.2756 383.229,-23.2756 238.229,-23.2756\"/>\n<text text-anchor=\"start\" x=\"241.229\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.21953886312515625</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"208.229,-20.7756 208.229,-93.7756 386.229,-93.7756 386.229,-20.7756 208.229,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M297.229,-150.4805C297.229,-142.2097 297.229,-133.6324 297.229,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"300.7291,-124.9614 297.229,-114.9614 293.7291,-124.9614 300.7291,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M375.0423,-160.3982C412.297,-137.6907 456.0085,-111.0477 489.6677,-90.5318\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"491.7214,-93.379 498.4387,-85.1857 488.0782,-87.4018 491.7214,-93.379\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 37
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hyALNuUaCNza"
+      },
+      "source": [
+        "## Posterior marginals given dsypnea=present, asia=visit, smoking=true"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "gDydpbab9Svz",
+        "outputId": "43f77ff1-e422-4ab4-c8ce-430126f3d21b"
+      },
+      "source": [
+        "evidence  = {'dysp': 0, 'asia': 0, 'smoke': 0}\n",
+        "marginals = get_marginals(evidence)\n",
+        "print('\\n')\n",
+        "for k, v in marginals.items():\n",
+        "  print(k, v)\n",
+        "h = visualization(marginals, model)\n",
+        "h"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/pgmpy/factors/discrete/DiscreteFactor.py:519: UserWarning: Found unknown state name. Trying to switch to using all state names as state numbers\n",
+            "  \"Found unknown state name. Trying to switch to using all state names as state numbers\"\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 869.42it/s]\n",
+            "Eliminating: lung: 100%|██████████| 4/4 [00:00<00:00, 168.82it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 644.06it/s]\n",
+            "Eliminating: bronc: 100%|██████████| 4/4 [00:00<00:00, 286.94it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 1146.22it/s]\n",
+            "Eliminating: lung: 100%|██████████| 4/4 [00:00<00:00, 377.60it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 777.44it/s]\n",
+            "Eliminating: lung: 100%|██████████| 4/4 [00:00<00:00, 366.00it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 609.64it/s]\n",
+            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 387.65it/s]\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "asia 0.0\n",
+            "tub 0.927240461401952\n",
+            "smoke 0.0\n",
+            "lung 0.8544809228039041\n",
+            "bronc 0.13274179236912156\n",
+            "either 0.7889973380656611\n",
+            "xray 0.7537675244010646\n",
+            "dysp 0.0\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7fa5dc7ead10>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: asia_net Pages: 1 -->\n<svg width=\"739pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 739.36 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>asia_net</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 735.3574,-570.2052 735.3574,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"137.1787\" cy=\"-508.9295\" rx=\"52.1524\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"111.1787,-520.9295 111.1787,-541.9295 163.1787,-541.9295 163.1787,-520.9295 111.1787,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"111.1787,-520.9295 111.1787,-541.9295 163.1787,-541.9295 163.1787,-520.9295 111.1787,-520.9295\"/>\n<text text-anchor=\"start\" x=\"122.6787\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"111.1787,-497.9295 111.1787,-518.9295 136.1787,-518.9295 136.1787,-497.9295 111.1787,-497.9295\"/>\n<text text-anchor=\"start\" x=\"114.1787\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"138.1787,-497.9295 138.1787,-518.9295 163.1787,-518.9295 163.1787,-497.9295 138.1787,-497.9295\"/>\n<text text-anchor=\"start\" x=\"141.1787\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.0</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"111.1787,-474.9295 111.1787,-495.9295 136.1787,-495.9295 136.1787,-474.9295 111.1787,-474.9295\"/>\n<text text-anchor=\"start\" x=\"115.6787\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"138.1787,-474.9295 138.1787,-495.9295 163.1787,-495.9295 163.1787,-474.9295 138.1787,-474.9295\"/>\n<text text-anchor=\"start\" x=\"141.1787\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.0</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"108.1787,-472.4295 108.1787,-545.4295 166.1787,-545.4295 166.1787,-472.4295 108.1787,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"137.1787\" cy=\"-358.3782\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"51.1787,-370.3782 51.1787,-391.3782 223.1787,-391.3782 223.1787,-370.3782 51.1787,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"51.1787,-370.3782 51.1787,-391.3782 223.1787,-391.3782 223.1787,-370.3782 51.1787,-370.3782\"/>\n<text text-anchor=\"start\" x=\"123.6787\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"51.1787,-347.3782 51.1787,-368.3782 76.1787,-368.3782 76.1787,-347.3782 51.1787,-347.3782\"/>\n<text text-anchor=\"start\" x=\"54.1787\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"78.1787,-347.3782 78.1787,-368.3782 223.1787,-368.3782 223.1787,-347.3782 78.1787,-347.3782\"/>\n<text text-anchor=\"start\" x=\"88.6787\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.927240461401952</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"51.1787,-324.3782 51.1787,-345.3782 76.1787,-345.3782 76.1787,-324.3782 51.1787,-324.3782\"/>\n<text text-anchor=\"start\" x=\"55.6787\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"78.1787,-324.3782 78.1787,-345.3782 223.1787,-345.3782 223.1787,-324.3782 78.1787,-324.3782\"/>\n<text text-anchor=\"start\" x=\"81.1787\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.07275953859804796</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"48.1787,-321.8782 48.1787,-394.8782 226.1787,-394.8782 226.1787,-321.8782 48.1787,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M137.1787,-451.5831C137.1787,-443.3123 137.1787,-434.7349 137.1787,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"140.6788,-426.064 137.1787,-416.064 133.6788,-426.064 140.6788,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"302.1787\" cy=\"-207.8269\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"216.1787,-219.8269 216.1787,-240.8269 388.1787,-240.8269 388.1787,-219.8269 216.1787,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"216.1787,-219.8269 216.1787,-240.8269 388.1787,-240.8269 388.1787,-219.8269 216.1787,-219.8269\"/>\n<text text-anchor=\"start\" x=\"282.1787\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"216.1787,-196.8269 216.1787,-217.8269 241.1787,-217.8269 241.1787,-196.8269 216.1787,-196.8269\"/>\n<text text-anchor=\"start\" x=\"219.1787\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"243.1787,-196.8269 243.1787,-217.8269 388.1787,-217.8269 388.1787,-196.8269 243.1787,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.1787\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.7889973380656611</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"216.1787,-173.8269 216.1787,-194.8269 241.1787,-194.8269 241.1787,-173.8269 216.1787,-173.8269\"/>\n<text text-anchor=\"start\" x=\"220.6787\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"243.1787,-173.8269 243.1787,-194.8269 388.1787,-194.8269 388.1787,-173.8269 243.1787,-173.8269\"/>\n<text text-anchor=\"start\" x=\"246.1787\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.21100266193433892</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"213.1787,-171.3269 213.1787,-244.3269 391.1787,-244.3269 391.1787,-171.3269 213.1787,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M194.4246,-306.1452C208.2467,-293.5335 223.1155,-279.9668 237.261,-267.06\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"240.0059,-269.2934 245.034,-259.9676 235.2878,-264.1224 240.0059,-269.2934\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"511.1787\" cy=\"-508.9295\" rx=\"53.9813\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"484.1787,-520.9295 484.1787,-541.9295 538.1787,-541.9295 538.1787,-520.9295 484.1787,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"484.1787,-520.9295 484.1787,-541.9295 538.1787,-541.9295 538.1787,-520.9295 484.1787,-520.9295\"/>\n<text text-anchor=\"start\" x=\"488.1787\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"484.1787,-497.9295 484.1787,-518.9295 510.1787,-518.9295 510.1787,-497.9295 484.1787,-497.9295\"/>\n<text text-anchor=\"start\" x=\"487.6787\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"512.1787,-497.9295 512.1787,-518.9295 538.1787,-518.9295 538.1787,-497.9295 512.1787,-497.9295\"/>\n<text text-anchor=\"start\" x=\"515.6787\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.0</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"484.1787,-474.9295 484.1787,-495.9295 510.1787,-495.9295 510.1787,-474.9295 484.1787,-474.9295\"/>\n<text text-anchor=\"start\" x=\"489.1787\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"512.1787,-474.9295 512.1787,-495.9295 538.1787,-495.9295 538.1787,-474.9295 512.1787,-474.9295\"/>\n<text text-anchor=\"start\" x=\"515.6787\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.0</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"481.1787,-472.4295 481.1787,-545.4295 541.1787,-545.4295 541.1787,-472.4295 481.1787,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"429.1787\" cy=\"-358.3782\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"343.1787,-370.3782 343.1787,-391.3782 515.1787,-391.3782 515.1787,-370.3782 343.1787,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"343.1787,-370.3782 343.1787,-391.3782 515.1787,-391.3782 515.1787,-370.3782 343.1787,-370.3782\"/>\n<text text-anchor=\"start\" x=\"412.1787\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"343.1787,-347.3782 343.1787,-368.3782 368.1787,-368.3782 368.1787,-347.3782 343.1787,-347.3782\"/>\n<text text-anchor=\"start\" x=\"346.1787\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"370.1787,-347.3782 370.1787,-368.3782 515.1787,-368.3782 515.1787,-347.3782 370.1787,-347.3782\"/>\n<text text-anchor=\"start\" x=\"376.6787\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.8544809228039041</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"343.1787,-324.3782 343.1787,-345.3782 368.1787,-345.3782 368.1787,-324.3782 343.1787,-324.3782\"/>\n<text text-anchor=\"start\" x=\"347.6787\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"370.1787,-324.3782 370.1787,-345.3782 515.1787,-345.3782 515.1787,-324.3782 370.1787,-324.3782\"/>\n<text text-anchor=\"start\" x=\"373.1787\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.14551907719609591</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"340.1787,-321.8782 340.1787,-394.8782 518.1787,-394.8782 518.1787,-321.8782 340.1787,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M484.1016,-459.2162C477.8563,-447.7499 471.122,-435.3858 464.5813,-423.3772\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"467.4856,-421.392 459.6287,-414.2842 461.3383,-424.7402 467.4856,-421.392\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"594.1787\" cy=\"-207.8269\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"508.1787,-219.8269 508.1787,-240.8269 680.1787,-240.8269 680.1787,-219.8269 508.1787,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"508.1787,-219.8269 508.1787,-240.8269 680.1787,-240.8269 680.1787,-219.8269 508.1787,-219.8269\"/>\n<text text-anchor=\"start\" x=\"573.6787\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"508.1787,-196.8269 508.1787,-217.8269 533.1787,-217.8269 533.1787,-196.8269 508.1787,-196.8269\"/>\n<text text-anchor=\"start\" x=\"511.1787\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"535.1787,-196.8269 535.1787,-217.8269 680.1787,-217.8269 680.1787,-196.8269 535.1787,-196.8269\"/>\n<text text-anchor=\"start\" x=\"538.1787\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.13274179236912156</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"508.1787,-173.8269 508.1787,-194.8269 533.1787,-194.8269 533.1787,-173.8269 508.1787,-173.8269\"/>\n<text text-anchor=\"start\" x=\"512.6787\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"535.1787,-173.8269 535.1787,-194.8269 680.1787,-194.8269 680.1787,-173.8269 535.1787,-173.8269\"/>\n<text text-anchor=\"start\" x=\"541.6787\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.8672582076308785</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"505.1787,-171.3269 505.1787,-244.3269 683.1787,-244.3269 683.1787,-171.3269 505.1787,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M547.4303,-465.9495C558.1804,-450.9389 568.7801,-433.3884 575.1787,-415.6539 591.3665,-370.7877 595.9299,-317.1071 596.5436,-275.5421\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"600.0436,-275.5457 596.6192,-265.5196 593.0438,-275.4929 600.0436,-275.5457\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M383.3288,-304.0258C373.9768,-292.9396 364.0701,-281.1956 354.5118,-269.8649\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"357.0845,-267.4865 347.9613,-262.0996 351.734,-272 357.0845,-267.4865\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"552.1787\" cy=\"-57.2756\" rx=\"52.1524\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"526.1787,-69.2756 526.1787,-90.2756 578.1787,-90.2756 578.1787,-69.2756 526.1787,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"526.1787,-69.2756 526.1787,-90.2756 578.1787,-90.2756 578.1787,-69.2756 526.1787,-69.2756\"/>\n<text text-anchor=\"start\" x=\"534.1787\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"526.1787,-46.2756 526.1787,-67.2756 551.1787,-67.2756 551.1787,-46.2756 526.1787,-46.2756\"/>\n<text text-anchor=\"start\" x=\"529.1787\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"553.1787,-46.2756 553.1787,-67.2756 578.1787,-67.2756 578.1787,-46.2756 553.1787,-46.2756\"/>\n<text text-anchor=\"start\" x=\"556.1787\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.0</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"526.1787,-23.2756 526.1787,-44.2756 551.1787,-44.2756 551.1787,-23.2756 526.1787,-23.2756\"/>\n<text text-anchor=\"start\" x=\"530.6787\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"553.1787,-23.2756 553.1787,-44.2756 578.1787,-44.2756 578.1787,-23.2756 553.1787,-23.2756\"/>\n<text text-anchor=\"start\" x=\"556.1787\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.0</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"523.1787,-20.7756 523.1787,-93.7756 581.1787,-93.7756 581.1787,-20.7756 523.1787,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M578.3003,-150.91C575.6797,-141.5162 572.9458,-131.7163 570.2757,-122.1452\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"573.5822,-120.9722 567.5237,-112.2805 566.8396,-122.8532 573.5822,-120.9722\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"302.1787\" cy=\"-57.2756\" rx=\"137.3577\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"216.1787,-69.2756 216.1787,-90.2756 388.1787,-90.2756 388.1787,-69.2756 216.1787,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"216.1787,-69.2756 216.1787,-90.2756 388.1787,-90.2756 388.1787,-69.2756 216.1787,-69.2756\"/>\n<text text-anchor=\"start\" x=\"285.1787\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"216.1787,-46.2756 216.1787,-67.2756 241.1787,-67.2756 241.1787,-46.2756 216.1787,-46.2756\"/>\n<text text-anchor=\"start\" x=\"219.1787\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"243.1787,-46.2756 243.1787,-67.2756 388.1787,-67.2756 388.1787,-46.2756 243.1787,-46.2756\"/>\n<text text-anchor=\"start\" x=\"249.6787\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.7537675244010646</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"216.1787,-23.2756 216.1787,-44.2756 241.1787,-44.2756 241.1787,-23.2756 216.1787,-23.2756\"/>\n<text text-anchor=\"start\" x=\"220.6787\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"243.1787,-23.2756 243.1787,-44.2756 388.1787,-44.2756 388.1787,-23.2756 243.1787,-23.2756\"/>\n<text text-anchor=\"start\" x=\"246.1787\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.24623247559893535</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"213.1787,-20.7756 213.1787,-93.7756 391.1787,-93.7756 391.1787,-20.7756 213.1787,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M302.1787,-150.4805C302.1787,-142.2097 302.1787,-133.6324 302.1787,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"305.6788,-124.9614 302.1787,-114.9614 298.6788,-124.9614 305.6788,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M380.5944,-160.6046C418.452,-137.8066 462.9622,-111.0023 497.1609,-90.4076\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"499.309,-93.1998 506.07,-85.0426 495.6978,-87.2032 499.309,-93.1998\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 38
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fxLt4NZEHEGp"
+      },
+      "source": [
+        "# Visualization of posterior marginals"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1ZgEQUrOHIyK"
+      },
+      "source": [
+        "\n",
+        "<img src=\"https://user-images.githubusercontent.com/4632336/118872284-40b65700-b89d-11eb-8739-bc94fce6808a.png?raw=true\">\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "C62naP3VJFbV"
+      },
+      "source": [
+        "# Explanatory text from the book.\n",
+        "\n",
+        "In this section,\n",
+        "we consider a hypothetical medical\n",
+        "model proposed in \\citep{Lauritzen88}\n",
+        "which is\n",
+        "known in the literature as the ``\\keywordDef{Asia network}''.\n",
+        "(The name comes  from the fact\n",
+        "that was designed to diagnoise various\n",
+        "lung diseases in Western patients returning from a trip to Asia.\n",
+        "Note that this example predates \n",
+        "the \\COVID pandemic by many years, and is a purely fictitious model.)\n",
+        "\n",
+        "\\cref{fig:pgmAsia1} shows the model, as well as the prior\n",
+        "marginal distributions over each node (assumed to be binary).\n",
+        "Now suppose the patient reports that they have \\keywordDef{Dyspnea},\n",
+        "aka shortness of breath.\n",
+        "We can represent this fact\n",
+        "``clamping'' the distribution to be 100\\% probability\n",
+        "that Dyspnea=Present, and 0\\% probability that Dyspnea=Absent.\n",
+        "We then propagate this new  information  through the network\n",
+        "to get the updated marginal distributions shown in\n",
+        "\\cref{fig:pgmAsia2}.\n",
+        "We see that the probability\n",
+        "of lung cancer has gone up from 5\\% to 10\\%,\n",
+        "and probability of bronchitis has gone up  from 45\\% to 83\\%.\n",
+        "\n",
+        "However, it could also be a an undiagnosed case of TB (tuberculosis),\n",
+        "which may have been caused by exposure to an infectious lung disease\n",
+        "that was prevalent in Asia at the time.\n",
+        "So he doctor asks the patient if they have recently been to Asia,\n",
+        "and they say yes.  \\cref{fig:pgmAsia3} shows the new belief state of each node.\n",
+        "We see that the probability of TB has increased from 2\\% to 9\\%.\n",
+        "However, Bronchitis remains the most likely explanation of the symptoms.\n",
+        "\n",
+        "To gain more information the doctor asks\n",
+        "if the patient smokes, and they say yes.\n",
+        "\\cref{fig:pgmAsia3} shows the new belief state of each node.\n",
+        "Now the probability of cancer and bronchitis have both gone up.\n",
+        "In addition, the posterior predicted probability that an X-ray\n",
+        "will show an abnormal result has gone up to 24\\%, so the doctor may decide\n",
+        "it is now worth ordering a test to verify this hypothesis.\n",
+        "\n",
+        "This example illustrates the nature of recursive Bayesian updating,\n",
+        "and how it can be useful for active learning and sequential decision making,\n",
+        "We will see more examples later in the book."
+      ]
+    }
+  ]
+}

--- a/notebooks/asia_pgm2.ipynb
+++ b/notebooks/asia_pgm2.ipynb
@@ -46,11 +46,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "p4SVMjkpbcJ7",
-        "outputId": "b23bc3c6-6918-4786-bf42-49a33ba6b15b"
+        "id": "p4SVMjkpbcJ7"
       },
       "source": [
         "!pip install  causalgraphicalmodels\n",
@@ -58,40 +54,7 @@
         "#!ls /usr/local/lib/python3.7/dist-packages/pgmpy/utils"
       ],
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Requirement already satisfied: causalgraphicalmodels in /usr/local/lib/python3.7/dist-packages (0.0.4)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (2.5.1)\n",
-            "Requirement already satisfied: pandas in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (1.1.5)\n",
-            "Requirement already satisfied: graphviz in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (0.10.1)\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (1.19.5)\n",
-            "Requirement already satisfied: decorator<5,>=4.3 in /usr/local/lib/python3.7/dist-packages (from networkx->causalgraphicalmodels) (4.4.2)\n",
-            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.7/dist-packages (from pandas->causalgraphicalmodels) (2.8.1)\n",
-            "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.7/dist-packages (from pandas->causalgraphicalmodels) (2018.9)\n",
-            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.7/dist-packages (from python-dateutil>=2.7.3->pandas->causalgraphicalmodels) (1.15.0)\n",
-            "Requirement already satisfied: pgmpy in /usr/local/lib/python3.7/dist-packages (0.1.14)\n",
-            "Requirement already satisfied: scikit-learn in /usr/local/lib/python3.7/dist-packages (from pgmpy) (0.22.2.post1)\n",
-            "Requirement already satisfied: pyparsing in /usr/local/lib/python3.7/dist-packages (from pgmpy) (2.4.7)\n",
-            "Requirement already satisfied: statsmodels in /usr/local/lib/python3.7/dist-packages (from pgmpy) (0.10.2)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.7/dist-packages (from pgmpy) (2.5.1)\n",
-            "Requirement already satisfied: torch in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.8.1+cu101)\n",
-            "Requirement already satisfied: tqdm in /usr/local/lib/python3.7/dist-packages (from pgmpy) (4.41.1)\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.19.5)\n",
-            "Requirement already satisfied: pandas in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.1.5)\n",
-            "Requirement already satisfied: joblib in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.0.1)\n",
-            "Requirement already satisfied: scipy in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.4.1)\n",
-            "Requirement already satisfied: patsy>=0.4.0 in /usr/local/lib/python3.7/dist-packages (from statsmodels->pgmpy) (0.5.1)\n",
-            "Requirement already satisfied: decorator<5,>=4.3 in /usr/local/lib/python3.7/dist-packages (from networkx->pgmpy) (4.4.2)\n",
-            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from torch->pgmpy) (3.7.4.3)\n",
-            "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.7/dist-packages (from pandas->pgmpy) (2018.9)\n",
-            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.7/dist-packages (from pandas->pgmpy) (2.8.1)\n",
-            "Requirement already satisfied: six in /usr/local/lib/python3.7/dist-packages (from patsy>=0.4.0->statsmodels->pgmpy) (1.15.0)\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -149,11 +112,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "l8xzIiLr0En0",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "8f2e8d79-0fee-4c0f-9865-627853bb20d9"
+        "id": "l8xzIiLr0En0"
       },
       "source": [
         "\n",
@@ -166,123 +125,24 @@
         "model.get_cpds()"
       ],
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Nodes:  ['asia', 'tub', 'smoke', 'lung', 'bronc', 'either', 'xray', 'dysp']\n",
-            "Edges:  [('asia', 'tub'), ('tub', 'either'), ('smoke', 'lung'), ('smoke', 'bronc'), ('lung', 'either'), ('bronc', 'dysp'), ('either', 'xray'), ('either', 'dysp')]\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "[<TabularCPD representing P(asia:2) at 0x7f9537efced0>,\n",
-              " <TabularCPD representing P(bronc:2 | smoke:2) at 0x7f9537efce50>,\n",
-              " <TabularCPD representing P(dysp:2 | bronc:2, either:2) at 0x7f9537f0a1d0>,\n",
-              " <TabularCPD representing P(either:2 | lung:2, tub:2) at 0x7f9537f0a590>,\n",
-              " <TabularCPD representing P(lung:2 | smoke:2) at 0x7f9537f0a290>,\n",
-              " <TabularCPD representing P(smoke:2) at 0x7f9537f0a850>,\n",
-              " <TabularCPD representing P(tub:2 | asia:2) at 0x7f9537f0a990>,\n",
-              " <TabularCPD representing P(xray:2 | either:2) at 0x7f9537f0ab10>]"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 6
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "d1GFKz5t5kxA",
-        "outputId": "e26e8f60-8922-49f7-cbd6-9cd8b4303d87"
+        "id": "d1GFKz5t5kxA"
       },
       "source": [
         "for c in model.get_cpds():\n",
         "  print(c)"
       ],
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "+-----------+------+\n",
-            "| asia(yes) | 0.01 |\n",
-            "+-----------+------+\n",
-            "| asia(no)  | 0.99 |\n",
-            "+-----------+------+\n",
-            "+------------+------------+-----------+\n",
-            "| smoke      | smoke(yes) | smoke(no) |\n",
-            "+------------+------------+-----------+\n",
-            "| bronc(yes) | 0.6        | 0.3       |\n",
-            "+------------+------------+-----------+\n",
-            "| bronc(no)  | 0.4        | 0.7       |\n",
-            "+------------+------------+-----------+\n",
-            "+-----------+-------------+------------+-------------+------------+\n",
-            "| bronc     | bronc(yes)  | bronc(yes) | bronc(no)   | bronc(no)  |\n",
-            "+-----------+-------------+------------+-------------+------------+\n",
-            "| either    | either(yes) | either(no) | either(yes) | either(no) |\n",
-            "+-----------+-------------+------------+-------------+------------+\n",
-            "| dysp(yes) | 0.9         | 0.8        | 0.7         | 0.1        |\n",
-            "+-----------+-------------+------------+-------------+------------+\n",
-            "| dysp(no)  | 0.1         | 0.2        | 0.3         | 0.9        |\n",
-            "+-----------+-------------+------------+-------------+------------+\n",
-            "+-------------+-----------+-----------+----------+----------+\n",
-            "| lung        | lung(yes) | lung(yes) | lung(no) | lung(no) |\n",
-            "+-------------+-----------+-----------+----------+----------+\n",
-            "| tub         | tub(yes)  | tub(no)   | tub(yes) | tub(no)  |\n",
-            "+-------------+-----------+-----------+----------+----------+\n",
-            "| either(yes) | 1.0       | 1.0       | 1.0      | 0.0      |\n",
-            "+-------------+-----------+-----------+----------+----------+\n",
-            "| either(no)  | 0.0       | 0.0       | 0.0      | 1.0      |\n",
-            "+-------------+-----------+-----------+----------+----------+\n",
-            "+-----------+------------+-----------+\n",
-            "| smoke     | smoke(yes) | smoke(no) |\n",
-            "+-----------+------------+-----------+\n",
-            "| lung(yes) | 0.1        | 0.01      |\n",
-            "+-----------+------------+-----------+\n",
-            "| lung(no)  | 0.9        | 0.99      |\n",
-            "+-----------+------------+-----------+\n",
-            "+------------+-----+\n",
-            "| smoke(yes) | 0.5 |\n",
-            "+------------+-----+\n",
-            "| smoke(no)  | 0.5 |\n",
-            "+------------+-----+\n",
-            "+----------+-----------+----------+\n",
-            "| asia     | asia(yes) | asia(no) |\n",
-            "+----------+-----------+----------+\n",
-            "| tub(yes) | 0.05      | 0.01     |\n",
-            "+----------+-----------+----------+\n",
-            "| tub(no)  | 0.95      | 0.99     |\n",
-            "+----------+-----------+----------+\n",
-            "+-----------+-------------+------------+\n",
-            "| either    | either(yes) | either(no) |\n",
-            "+-----------+-------------+------------+\n",
-            "| xray(yes) | 0.98        | 0.05       |\n",
-            "+-----------+-------------+------------+\n",
-            "| xray(no)  | 0.02        | 0.95       |\n",
-            "+-----------+-------------+------------+\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "8jzeJCpE50kw",
-        "outputId": "44e81b76-a31c-44d4-e1f8-b4a47e26c399"
+        "id": "8jzeJCpE50kw"
       },
       "source": [
         "asia_cpd = model.get_cpds('asia')\n",
@@ -291,29 +151,12 @@
         "\n"
       ],
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "+-----------+------+\n",
-            "| asia(yes) | 0.01 |\n",
-            "+-----------+------+\n",
-            "| asia(no)  | 0.99 |\n",
-            "+-----------+------+\n",
-            "[0.01 0.99]\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "VDNdkr0_6TsN",
-        "outputId": "e73d679c-2e43-4bfd-98fc-fc57cfc1b66f"
+        "id": "VDNdkr0_6TsN"
       },
       "source": [
         "smoking_cpd = model.get_cpds()[5]\n",
@@ -322,53 +165,23 @@
         "smoking_prior_true = smoking_cpd.values[1]"
       ],
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "+------------+-----+\n",
-            "| smoke(yes) | 0.5 |\n",
-            "+------------+-----+\n",
-            "| smoke(no)  | 0.5 |\n",
-            "+------------+-----+\n",
-            "[0.5 0.5]\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "YzCS6iizCkIA",
-        "outputId": "daf6c223-0c53-4f1c-f3e9-614f6249f701"
+        "id": "YzCS6iizCkIA"
       },
       "source": [
         "print(pgm.get_state_names(model))"
       ],
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "{'asia': ['yes', 'no'], 'smoke': ['yes', 'no'], 'bronc': ['yes', 'no'], 'either': ['yes', 'no'], 'dysp': ['yes', 'no'], 'lung': ['yes', 'no'], 'tub': ['yes', 'no'], 'xray': ['yes', 'no']}\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "K8gIy5Bk2XJR",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 385
-        },
-        "outputId": "606354c0-b2f3-4381-adaa-ddba03e56bd4"
+        "id": "K8gIy5Bk2XJR"
       },
       "source": [
         "asia = CausalGraphicalModel(nodes = model.nodes(), edges=model.edges())\n",
@@ -378,35 +191,7 @@
         "out.render()"
       ],
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<graphviz.dot.Digraph at 0x7f9537ed3e10>"
-            ],
-            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: %3 Pages: 1 -->\n<svg width=\"196pt\" height=\"260pt\"\n viewBox=\"0.00 0.00 196.50 260.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 256)\">\n<title>%3</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-256 192.4971,-256 192.4971,4 -4,4\"/>\n<!-- dysp -->\n<g id=\"node1\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"36.4971\" cy=\"-18\" rx=\"28.6953\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"36.4971\" y=\"-14.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">dysp</text>\n</g>\n<!-- smoke -->\n<g id=\"node2\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.4971\" cy=\"-234\" rx=\"35.194\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"57.4971\" y=\"-230.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">smoke</text>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"88.4971\" cy=\"-162\" rx=\"27.8951\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"88.4971\" y=\"-158.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">lung</text>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M65.16,-216.2022C68.6888,-208.0064 72.953,-198.1024 76.8659,-189.0145\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"80.1824,-190.162 80.9223,-179.593 73.753,-187.3938 80.1824,-190.162\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"32.4971\" cy=\"-90\" rx=\"32.4942\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"32.4971\" y=\"-86.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">bronc</text>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M54.3814,-216.0535C50.1147,-191.4774 42.4104,-147.1008 37.3751,-118.0974\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"40.8111,-117.4266 35.6521,-108.1727 33.9143,-118.624 40.8111,-117.4266\"/>\n</g>\n<!-- asia -->\n<g id=\"node3\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"161.4971\" cy=\"-234\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"161.4971\" y=\"-230.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">asia</text>\n</g>\n<!-- tub -->\n<g id=\"node8\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"161.4971\" cy=\"-162\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"161.4971\" y=\"-158.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">tub</text>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M161.4971,-215.8314C161.4971,-208.131 161.4971,-198.9743 161.4971,-190.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"164.9972,-190.4132 161.4971,-180.4133 157.9972,-190.4133 164.9972,-190.4132\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"114.4971\" cy=\"-90\" rx=\"31.3957\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"114.4971\" y=\"-86.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">either</text>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M94.9241,-144.2022C97.8304,-136.1541 101.3314,-126.4588 104.5642,-117.5067\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"107.9494,-118.4369 108.054,-107.8425 101.3655,-116.0593 107.9494,-118.4369\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M33.5065,-71.8314C33.9343,-64.131 34.443,-54.9743 34.9184,-46.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"38.414,-46.592 35.4742,-36.4133 31.4248,-46.2037 38.414,-46.592\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M97.9553,-74.7307C87.0236,-64.6398 72.5207,-51.2526 60.3488,-40.0169\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"62.4697,-37.2115 52.7476,-33.0004 57.7217,-42.3551 62.4697,-37.2115\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"114.4971\" cy=\"-18\" rx=\"27.0966\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"114.4971\" y=\"-14.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">xray</text>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M114.4971,-71.8314C114.4971,-64.131 114.4971,-54.9743 114.4971,-46.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"117.9972,-46.4132 114.4971,-36.4133 110.9972,-46.4133 117.9972,-46.4132\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M150.5962,-145.3008C144.8659,-136.5224 137.7166,-125.5703 131.2957,-115.7339\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"134.0624,-113.5693 125.6653,-107.1086 128.2007,-117.3956 134.0624,-113.5693\"/>\n</g>\n</g>\n</svg>\n"
-          },
-          "metadata": {
-            "tags": []
-          }
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'Digraph.gv.pdf'"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 11
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -452,11 +237,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "wIj_U9mC-Q3M",
-        "outputId": "c2111b48-ff58-4778-e56a-bb96c50f4b1c"
+        "id": "wIj_U9mC-Q3M"
       },
       "source": [
         "evidence = {}\n",
@@ -469,82 +250,18 @@
         "assert np.allclose(asia_prior, marginals['asia'])"
       ],
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1187.08it/s]\n",
-            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 282.78it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1229.07it/s]\n",
-            "Eliminating: smoke: 100%|██████████| 7/7 [00:00<00:00, 235.62it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1545.60it/s]\n",
-            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 311.00it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1322.77it/s]\n",
-            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 230.17it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 2006.71it/s]\n",
-            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 269.39it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1614.52it/s]\n",
-            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 388.88it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 2224.25it/s]\n",
-            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 266.68it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 492.07it/s]\n",
-            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 354.11it/s]"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "\n",
-            "asia [0.01 0.99]\n",
-            "tub [0.0104 0.9896]\n",
-            "smoke [0.5 0.5]\n",
-            "lung [0.055 0.945]\n",
-            "bronc [0.45 0.55]\n",
-            "either [0.064828 0.935172]\n",
-            "xray [0.11029004 0.88970996]\n",
-            "dysp [0.4359706 0.5640294]\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "\n"
-          ],
-          "name": "stderr"
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 785
-        },
-        "id": "oC0BWo-PDQU8",
-        "outputId": "d57daa1d-d22c-4763-d673-81b8506a6718"
+        "id": "oC0BWo-PDQU8"
       },
       "source": [
         "pgm.visualize_marginals(marginals, model)"
       ],
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<graphviz.dot.Digraph at 0x7f9537e704d0>"
-            ],
-            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: pgm Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>pgm</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.01</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.99</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.01</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.99</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.06</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.94</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.50</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.50</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.06</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.94</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.45</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.55</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.44</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.56</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"144.4828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.11</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.89</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
-          },
-          "metadata": {
-            "tags": []
-          }
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -558,12 +275,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "id": "ZMcpy_pA67bi",
-        "outputId": "45e783e2-c0cc-4fbf-8b4b-7e35ed8dac88"
+        "id": "ZMcpy_pA67bi"
       },
       "source": [
         "evidence  = {'dysp': 0}\n",
@@ -573,58 +285,7 @@
         "  print(k, v)"
       ],
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "/usr/local/lib/python3.7/dist-packages/pgmpy/factors/discrete/DiscreteFactor.py:519: UserWarning: Found unknown state name. Trying to switch to using all state names as state numbers\n",
-            "  \"Found unknown state name. Trying to switch to using all state names as state numbers\"\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 2149.64it/s]\n",
-            "Eliminating: tub: 100%|██████████| 6/6 [00:00<00:00, 419.62it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 2181.13it/s]\n",
-            "Eliminating: asia: 100%|██████████| 6/6 [00:00<00:00, 97.14it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1314.28it/s]\n",
-            "Eliminating: tub: 100%|██████████| 6/6 [00:00<00:00, 150.66it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 982.73it/s]\n",
-            "Eliminating: tub: 100%|██████████| 6/6 [00:00<00:00, 363.14it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1535.25it/s]\n",
-            "Eliminating: tub: 100%|██████████| 6/6 [00:00<00:00, 90.77it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1102.75it/s]\n",
-            "Eliminating: tub: 100%|██████████| 6/6 [00:00<00:00, 167.46it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1379.86it/s]\n",
-            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 161.83it/s]\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "\n",
-            "asia [0.01032495 0.98967505]\n",
-            "tub [0.01884531 0.98115469]\n",
-            "smoke [0.63399688 0.36600312]\n",
-            "lung [0.10275922 0.89724078]\n",
-            "bronc [0.83396734 0.16603266]\n",
-            "either [0.12053583 0.87946417]\n",
-            "xray [0.16209833 0.83790167]\n",
-            "dysp [1. 0.]\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<graphviz.dot.Digraph at 0x7f9537647890>"
-            ],
-            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: pgm Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>pgm</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.01</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.99</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.02</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.98</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.12</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.88</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.63</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.37</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.10</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.90</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.83</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.17</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.16</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.84</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
-          },
-          "metadata": {
-            "tags": []
-          }
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -649,12 +310,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "id": "eJJhZFWf70pl",
-        "outputId": "f791be9a-fdf9-4312-e8c8-775db76249de"
+        "id": "eJJhZFWf70pl"
       },
       "source": [
         "evidence  = {'dysp': 'yes', 'asia': 'yes'}\n",
@@ -664,54 +320,7 @@
         "  print(k, v)"
       ],
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1538.63it/s]\n",
-            "Eliminating: smoke: 100%|██████████| 5/5 [00:00<00:00, 406.24it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 2012.04it/s]\n",
-            "Eliminating: tub: 100%|██████████| 5/5 [00:00<00:00, 355.66it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 466.30it/s]\n",
-            "Eliminating: tub: 100%|██████████| 5/5 [00:00<00:00, 321.76it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1888.65it/s]\n",
-            "Eliminating: tub: 100%|██████████| 5/5 [00:00<00:00, 366.27it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 852.43it/s]\n",
-            "Eliminating: tub: 100%|██████████| 5/5 [00:00<00:00, 376.39it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 461.88it/s]\n",
-            "Eliminating: either: 100%|██████████| 5/5 [00:00<00:00, 268.96it/s]\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "\n",
-            "asia [1. 0.]\n",
-            "tub [0.08775096 0.91224904]\n",
-            "smoke [0.62591986 0.37408014]\n",
-            "lung [0.09952515 0.90047485]\n",
-            "bronc [0.81140207 0.18859793]\n",
-            "either [0.18229985 0.81770015]\n",
-            "xray [0.21953886 0.78046114]\n",
-            "dysp [1. 0.]\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<graphviz.dot.Digraph at 0x7f953763e650>"
-            ],
-            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: pgm Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>pgm</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.09</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.91</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.18</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.82</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.63</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.37</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.10</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.90</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.81</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.19</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.22</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.78</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
-          },
-          "metadata": {
-            "tags": []
-          }
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -736,12 +345,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "id": "gDydpbab9Svz",
-        "outputId": "7bf2565a-b243-4867-ab6d-b4cc3005ed26"
+        "id": "gDydpbab9Svz"
       },
       "source": [
         "evidence  = {'dysp': 'yes', 'asia': 'yes', 'smoke': 'yes'}\n",
@@ -751,52 +355,7 @@
         "  print(k, v)"
       ],
       "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 424.42it/s]\n",
-            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 198.50it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 184.01it/s]\n",
-            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 176.03it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 723.90it/s]\n",
-            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 234.53it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 573.97it/s]\n",
-            "Eliminating: xray: 100%|██████████| 4/4 [00:00<00:00, 288.49it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 688.27it/s]\n",
-            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 176.36it/s]\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "\n",
-            "asia [1. 0.]\n",
-            "tub [0.07275954 0.92724046]\n",
-            "smoke [1. 0.]\n",
-            "lung [0.14551908 0.85448092]\n",
-            "bronc [0.86725821 0.13274179]\n",
-            "either [0.21100266 0.78899734]\n",
-            "xray [0.24623248 0.75376752]\n",
-            "dysp [1. 0.]\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<graphviz.dot.Digraph at 0x7f95376646d0>"
-            ],
-            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: pgm Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>pgm</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.07</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.93</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.21</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.79</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.15</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.85</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.87</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.13</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.25</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.75</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
-          },
-          "metadata": {
-            "tags": []
-          }
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",

--- a/notebooks/asia_pgm2.ipynb
+++ b/notebooks/asia_pgm2.ipynb
@@ -1,0 +1,858 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "Copy of asia_pgm.ipynb",
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "caeOoFYBb5p2"
+      },
+      "source": [
+        "# The \"Asia\"  graphical model\n",
+        "\n",
+        "We illustrate inference in the \"Asia\" medical diagnosis network.\n",
+        "Network is from http://www.bnlearn.com/bnrepository/#asia.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "p4SVMjkpbcJ7",
+        "outputId": "56637954-ef6c-417e-f213-cd4faac87d3d"
+      },
+      "source": [
+        "!pip install  causalgraphicalmodels\n",
+        "!pip install pgmpy\n",
+        "\n",
+        "#!ls /usr/local/lib/python3.7/dist-packages/pgmpy/utils"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Collecting causalgraphicalmodels\n",
+            "  Downloading https://files.pythonhosted.org/packages/c8/ee/3b2d184576f3cb4873cebfc696e8e5c1e53eaef691f38aea76c206f9f916/causalgraphicalmodels-0.0.4-py3-none-any.whl\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (1.19.5)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (2.5.1)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (1.1.5)\n",
+            "Requirement already satisfied: graphviz in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (0.10.1)\n",
+            "Requirement already satisfied: decorator<5,>=4.3 in /usr/local/lib/python3.7/dist-packages (from networkx->causalgraphicalmodels) (4.4.2)\n",
+            "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.7/dist-packages (from pandas->causalgraphicalmodels) (2018.9)\n",
+            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.7/dist-packages (from pandas->causalgraphicalmodels) (2.8.1)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.7/dist-packages (from python-dateutil>=2.7.3->pandas->causalgraphicalmodels) (1.15.0)\n",
+            "Installing collected packages: causalgraphicalmodels\n",
+            "Successfully installed causalgraphicalmodels-0.0.4\n",
+            "Collecting pgmpy\n",
+            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/a3/0e/d9fadbfaa35e010c04d43acd3ae9fbefec98897dd7d61a6b7eb5a8b34072/pgmpy-0.1.14-py3-none-any.whl (331kB)\n",
+            "\u001b[K     |████████████████████████████████| 337kB 8.0MB/s \n",
+            "\u001b[?25hRequirement already satisfied: scikit-learn in /usr/local/lib/python3.7/dist-packages (from pgmpy) (0.22.2.post1)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.19.5)\n",
+            "Requirement already satisfied: scipy in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.4.1)\n",
+            "Requirement already satisfied: torch in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.8.1+cu101)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.1.5)\n",
+            "Requirement already satisfied: pyparsing in /usr/local/lib/python3.7/dist-packages (from pgmpy) (2.4.7)\n",
+            "Requirement already satisfied: joblib in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.0.1)\n",
+            "Requirement already satisfied: tqdm in /usr/local/lib/python3.7/dist-packages (from pgmpy) (4.41.1)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.7/dist-packages (from pgmpy) (2.5.1)\n",
+            "Requirement already satisfied: statsmodels in /usr/local/lib/python3.7/dist-packages (from pgmpy) (0.10.2)\n",
+            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from torch->pgmpy) (3.7.4.3)\n",
+            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.7/dist-packages (from pandas->pgmpy) (2.8.1)\n",
+            "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.7/dist-packages (from pandas->pgmpy) (2018.9)\n",
+            "Requirement already satisfied: decorator<5,>=4.3 in /usr/local/lib/python3.7/dist-packages (from networkx->pgmpy) (4.4.2)\n",
+            "Requirement already satisfied: patsy>=0.4.0 in /usr/local/lib/python3.7/dist-packages (from statsmodels->pgmpy) (0.5.1)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.7/dist-packages (from python-dateutil>=2.7.3->pandas->pgmpy) (1.15.0)\n",
+            "Installing collected packages: pgmpy\n",
+            "Successfully installed pgmpy-0.1.14\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Go1UPp8eMIyC"
+      },
+      "source": [
+        "from causalgraphicalmodels import CausalGraphicalModel\n",
+        "import pgmpy\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "from graphviz import Digraph"
+      ],
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "u_-A-Hai4LbM"
+      },
+      "source": [
+        "# Model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Il1OHrxj3e8Y"
+      },
+      "source": [
+        "#from pgmpy.utils import get_example_model\n",
+        "#asia = get_example_model('asia')\n",
+        "# No such file or directory: 'pgmpy/utils/example_models/asia.bif.gz'"
+      ],
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "OGsv1dt81oyI"
+      },
+      "source": [
+        "#!wget https://raw.githubusercontent.com/d2l-ai/d2l-en/master/d2l/torch.py -q -O d2l.py\n",
+        "\n",
+        "!wget https://www.bnlearn.com/bnrepository/asia/asia.bif.gz -q -O asia.bif.gz\n",
+        "!gunzip asia.bif.gz"
+      ],
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "l8xzIiLr0En0",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "7ed97f8a-3d40-4f20-caf1-41a707e6c35f"
+      },
+      "source": [
+        "from pgmpy.readwrite import BIFReader, BIFWriter\n",
+        "reader = BIFReader(\"asia.bif\")\n",
+        "model = reader.get_model()\n",
+        "\n",
+        "print(\"Nodes: \", model.nodes())\n",
+        "print(\"Edges: \", model.edges())\n",
+        "model.get_cpds()"
+      ],
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Nodes:  ['asia', 'tub', 'smoke', 'lung', 'bronc', 'either', 'xray', 'dysp']\n",
+            "Edges:  [('asia', 'tub'), ('tub', 'either'), ('smoke', 'lung'), ('smoke', 'bronc'), ('lung', 'either'), ('bronc', 'dysp'), ('either', 'xray'), ('either', 'dysp')]\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[<TabularCPD representing P(asia:2) at 0x7f5bb534f090>,\n",
+              " <TabularCPD representing P(bronc:2 | smoke:2) at 0x7f5bb59f3950>,\n",
+              " <TabularCPD representing P(dysp:2 | bronc:2, either:2) at 0x7f5bb6a11c10>,\n",
+              " <TabularCPD representing P(either:2 | lung:2, tub:2) at 0x7f5bb53c4f90>,\n",
+              " <TabularCPD representing P(lung:2 | smoke:2) at 0x7f5bb5355bd0>,\n",
+              " <TabularCPD representing P(smoke:2) at 0x7f5bb5355e10>,\n",
+              " <TabularCPD representing P(tub:2 | asia:2) at 0x7f5bb5355a90>,\n",
+              " <TabularCPD representing P(xray:2 | either:2) at 0x7f5bb5355c90>]"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 5
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "d1GFKz5t5kxA",
+        "outputId": "1affbcfd-c535-45c7-a5db-fce1530886cf"
+      },
+      "source": [
+        "for c in model.get_cpds():\n",
+        "  print(c)"
+      ],
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "+-----------+------+\n",
+            "| asia(yes) | 0.01 |\n",
+            "+-----------+------+\n",
+            "| asia(no)  | 0.99 |\n",
+            "+-----------+------+\n",
+            "+------------+------------+-----------+\n",
+            "| smoke      | smoke(yes) | smoke(no) |\n",
+            "+------------+------------+-----------+\n",
+            "| bronc(yes) | 0.6        | 0.3       |\n",
+            "+------------+------------+-----------+\n",
+            "| bronc(no)  | 0.4        | 0.7       |\n",
+            "+------------+------------+-----------+\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "| bronc     | bronc(yes)  | bronc(yes) | bronc(no)   | bronc(no)  |\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "| either    | either(yes) | either(no) | either(yes) | either(no) |\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "| dysp(yes) | 0.9         | 0.8        | 0.7         | 0.1        |\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "| dysp(no)  | 0.1         | 0.2        | 0.3         | 0.9        |\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "| lung        | lung(yes) | lung(yes) | lung(no) | lung(no) |\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "| tub         | tub(yes)  | tub(no)   | tub(yes) | tub(no)  |\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "| either(yes) | 1.0       | 1.0       | 1.0      | 0.0      |\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "| either(no)  | 0.0       | 0.0       | 0.0      | 1.0      |\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "+-----------+------------+-----------+\n",
+            "| smoke     | smoke(yes) | smoke(no) |\n",
+            "+-----------+------------+-----------+\n",
+            "| lung(yes) | 0.1        | 0.01      |\n",
+            "+-----------+------------+-----------+\n",
+            "| lung(no)  | 0.9        | 0.99      |\n",
+            "+-----------+------------+-----------+\n",
+            "+------------+-----+\n",
+            "| smoke(yes) | 0.5 |\n",
+            "+------------+-----+\n",
+            "| smoke(no)  | 0.5 |\n",
+            "+------------+-----+\n",
+            "+----------+-----------+----------+\n",
+            "| asia     | asia(yes) | asia(no) |\n",
+            "+----------+-----------+----------+\n",
+            "| tub(yes) | 0.05      | 0.01     |\n",
+            "+----------+-----------+----------+\n",
+            "| tub(no)  | 0.95      | 0.99     |\n",
+            "+----------+-----------+----------+\n",
+            "+-----------+-------------+------------+\n",
+            "| either    | either(yes) | either(no) |\n",
+            "+-----------+-------------+------------+\n",
+            "| xray(yes) | 0.98        | 0.05       |\n",
+            "+-----------+-------------+------------+\n",
+            "| xray(no)  | 0.02        | 0.95       |\n",
+            "+-----------+-------------+------------+\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "8jzeJCpE50kw",
+        "outputId": "f8d0f222-e7fb-4a05-a8a7-26c2c879b9c5"
+      },
+      "source": [
+        "asia_cpd = model.get_cpds()[0]\n",
+        "print(asia_cpd)\n",
+        "print(asia_cpd.values)\n",
+        "asia_prior_true = asia_cpd.values[1]"
+      ],
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "+-----------+------+\n",
+            "| asia(yes) | 0.01 |\n",
+            "+-----------+------+\n",
+            "| asia(no)  | 0.99 |\n",
+            "+-----------+------+\n",
+            "[0.01 0.99]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "VDNdkr0_6TsN",
+        "outputId": "985ac72a-a1f8-4144-ef84-4bf2fbfafc18"
+      },
+      "source": [
+        "smoking_cpd = model.get_cpds()[5]\n",
+        "print(smoking_cpd)\n",
+        "print(smoking_cpd.values)\n",
+        "smoking_prior_true = smoking_cpd.values[1]"
+      ],
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "+------------+-----+\n",
+            "| smoke(yes) | 0.5 |\n",
+            "+------------+-----+\n",
+            "| smoke(no)  | 0.5 |\n",
+            "+------------+-----+\n",
+            "[0.5 0.5]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "K8gIy5Bk2XJR",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 388
+        },
+        "outputId": "61f875e9-925f-45b5-fb0b-85f67b01b1a6"
+      },
+      "source": [
+        "asia = CausalGraphicalModel(nodes = model.nodes(), edges=model.edges())\n",
+        "nodes = model.nodes()\n",
+        "out = asia.draw()\n",
+        "display(out)\n",
+        "out.render()"
+      ],
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7f5bb531f8d0>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: %3 Pages: 1 -->\n<svg width=\"196pt\" height=\"260pt\"\n viewBox=\"0.00 0.00 196.50 260.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 256)\">\n<title>%3</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-256 192.4971,-256 192.4971,4 -4,4\"/>\n<!-- tub -->\n<g id=\"node1\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"161.4971\" cy=\"-162\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"161.4971\" y=\"-158.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">tub</text>\n</g>\n<!-- either -->\n<g id=\"node5\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"114.4971\" cy=\"-90\" rx=\"31.3957\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"114.4971\" y=\"-86.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">either</text>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M150.5962,-145.3008C144.8659,-136.5224 137.7166,-125.5703 131.2957,-115.7339\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"134.0624,-113.5693 125.6653,-107.1086 128.2007,-117.3956 134.0624,-113.5693\"/>\n</g>\n<!-- lung -->\n<g id=\"node2\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"88.4971\" cy=\"-162\" rx=\"27.8951\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"88.4971\" y=\"-158.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">lung</text>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M94.9241,-144.2022C97.8304,-136.1541 101.3314,-126.4588 104.5642,-117.5067\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"107.9494,-118.4369 108.054,-107.8425 101.3655,-116.0593 107.9494,-118.4369\"/>\n</g>\n<!-- asia -->\n<g id=\"node3\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"161.4971\" cy=\"-234\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"161.4971\" y=\"-230.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">asia</text>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M161.4971,-215.8314C161.4971,-208.131 161.4971,-198.9743 161.4971,-190.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"164.9972,-190.4132 161.4971,-180.4133 157.9972,-190.4133 164.9972,-190.4132\"/>\n</g>\n<!-- xray -->\n<g id=\"node4\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"114.4971\" cy=\"-18\" rx=\"27.0966\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"114.4971\" y=\"-14.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">xray</text>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M114.4971,-71.8314C114.4971,-64.131 114.4971,-54.9743 114.4971,-46.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"117.9972,-46.4132 114.4971,-36.4133 110.9972,-46.4133 117.9972,-46.4132\"/>\n</g>\n<!-- dysp -->\n<g id=\"node6\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"36.4971\" cy=\"-18\" rx=\"28.6953\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"36.4971\" y=\"-14.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">dysp</text>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M97.9553,-74.7307C87.0236,-64.6398 72.5207,-51.2526 60.3488,-40.0169\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"62.4697,-37.2115 52.7476,-33.0004 57.7217,-42.3551 62.4697,-37.2115\"/>\n</g>\n<!-- bronc -->\n<g id=\"node7\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"32.4971\" cy=\"-90\" rx=\"32.4942\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"32.4971\" y=\"-86.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">bronc</text>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M33.5065,-71.8314C33.9343,-64.131 34.443,-54.9743 34.9184,-46.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"38.414,-46.592 35.4742,-36.4133 31.4248,-46.2037 38.414,-46.592\"/>\n</g>\n<!-- smoke -->\n<g id=\"node8\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.4971\" cy=\"-234\" rx=\"35.194\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"57.4971\" y=\"-230.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">smoke</text>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M65.16,-216.2022C68.6888,-208.0064 72.953,-198.1024 76.8659,-189.0145\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"80.1824,-190.162 80.9223,-179.593 73.753,-187.3938 80.1824,-190.162\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M54.3814,-216.0535C50.1147,-191.4774 42.4104,-147.1008 37.3751,-118.0974\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"40.8111,-117.4266 35.6521,-108.1727 33.9143,-118.624 40.8111,-117.4266\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            },
+            "text/plain": [
+              "'Digraph.gv.pdf'"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 9
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3s_MxAup4Ol2"
+      },
+      "source": [
+        "# Inference"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "dJwoaVgi47Oe"
+      },
+      "source": [
+        "from pgmpy.inference import VariableElimination\n",
+        "infer = VariableElimination(model)"
+      ],
+      "execution_count": 10,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "RENNeAKA9nbj"
+      },
+      "source": [
+        "def get_marginals(evidence = {}):\n",
+        "  nodes = model.nodes()\n",
+        "  num_nodes = len(nodes)\n",
+        "  marginals = dict()\n",
+        "  for n in nodes:\n",
+        "    if n in evidence: # observed nodes\n",
+        "      v = evidence[n]\n",
+        "      if v == 1:      \n",
+        "        marginals[n] = 1.0 # clamped to state 1\n",
+        "      else:\n",
+        "        marginals[n] = 0.0 # clamped to state 0\n",
+        "    else:\n",
+        "      probs = infer.query([n], evidence=evidence).values\n",
+        "      marginals[n] = probs[1] # probability in state 1\n",
+        "  return marginals\n"
+      ],
+      "execution_count": 11,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "r1_t_YvN0XwF"
+      },
+      "source": [
+        "def visualization(marginals, model):\n",
+        "  h = Digraph('asia_net')\n",
+        "  titles = list(marginals.keys())\n",
+        "  yes_prob = list(marginals.values())\n",
+        "  no_prob = [1 - x for x in yes_prob]\n",
+        "  for i in range(len(marginals)):\n",
+        "    h.node(titles[i], label='''<<TABLE>\n",
+        "      <TR PORT=\"header\">\n",
+        "          <TD BGCOLOR=\"#d23939\" COLSPAN=\"2\"> {} </TD>\n",
+        "      </TR>\n",
+        "      <TR>\n",
+        "        <TD>yes</TD>\n",
+        "        <TD>{:.2f}</TD>\n",
+        "      </TR>\n",
+        "      <TR>\n",
+        "        <TD>no</TD>\n",
+        "        <TD>{:.2f}</TD>\n",
+        "      </TR>\n",
+        "    </TABLE>>'''.format(titles[i], yes_prob[i], no_prob[i]))\n",
+        "\n",
+        "  edges = (model.edges())\n",
+        "  for item in edges:\n",
+        "    edge = list(item)\n",
+        "    h.edge(edge[0], edge[1])\n",
+        "  \n",
+        "  return h\n"
+      ],
+      "execution_count": 12,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Fo1Z_lqa4fnB"
+      },
+      "source": [
+        "## Prior marginals"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "wIj_U9mC-Q3M",
+        "outputId": "6ef551bf-acee-4612-ea2d-5ff3af30824b"
+      },
+      "source": [
+        "marginals = get_marginals()\n",
+        "for k, v in marginals.items():\n",
+        "  print(k, v)\n",
+        "assert np.allclose(asia_prior_true, marginals['asia']) #Asia (0.5, 0.5)\n",
+        "h = visualization(marginals, model)\n",
+        "h"
+      ],
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1424.56it/s]\n",
+            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 259.84it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1044.36it/s]\n",
+            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 236.92it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 917.91it/s]\n",
+            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 253.14it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 2309.64it/s]\n",
+            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 369.69it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 2028.05it/s]\n",
+            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 379.30it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1937.71it/s]\n",
+            "Eliminating: xray: 100%|██████████| 7/7 [00:00<00:00, 277.38it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 878.73it/s]\n",
+            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 261.39it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 2573.19it/s]\n",
+            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 325.55it/s]\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "asia 0.99\n",
+            "tub 0.9896\n",
+            "smoke 0.49999999999999994\n",
+            "lung 0.945\n",
+            "bronc 0.55\n",
+            "either 0.935172\n",
+            "xray 0.88970996\n",
+            "dysp 0.5640294\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7f5bb5300f90>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: asia_net Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>asia_net</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.99</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.01</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.99</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.01</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.94</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.06</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.50</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.50</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.94</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.06</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.55</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.45</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.56</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.44</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.89</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"144.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.11</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 13
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "StB-XG1z7FEP"
+      },
+      "source": [
+        "## Posterior marginals given dsypnea=present"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "ZMcpy_pA67bi",
+        "outputId": "ea928d8a-3a5b-47fe-c724-7b8992622d81"
+      },
+      "source": [
+        "evidence  = {'dysp': 0}\n",
+        "marginals = get_marginals(evidence)\n",
+        "print('\\n')\n",
+        "for k, v in marginals.items():\n",
+        "  print(k, v)\n",
+        "h = visualization(marginals, model)\n",
+        "h"
+      ],
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/pgmpy/factors/discrete/DiscreteFactor.py:519: UserWarning: Found unknown state name. Trying to switch to using all state names as state numbers\n",
+            "  \"Found unknown state name. Trying to switch to using all state names as state numbers\"\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1096.84it/s]\n",
+            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 313.34it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1172.63it/s]\n",
+            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 310.75it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1788.74it/s]\n",
+            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 251.74it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1333.64it/s]\n",
+            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 220.39it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 776.51it/s]\n",
+            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 248.01it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1301.77it/s]\n",
+            "Eliminating: xray: 100%|██████████| 6/6 [00:00<00:00, 252.02it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1831.57it/s]\n",
+            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 261.85it/s]\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "asia 0.9896750491890968\n",
+            "tub 0.9811546925411943\n",
+            "smoke 0.3660031203938981\n",
+            "lung 0.8972407772450711\n",
+            "bronc 0.1660326636704402\n",
+            "either 0.8794641657029166\n",
+            "xray 0.8379016741037125\n",
+            "dysp 0.0\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7f5bb5345bd0>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: asia_net Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>asia_net</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.99</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.01</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.98</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.02</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.88</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.12</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.37</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.63</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.90</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.10</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.17</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.83</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.84</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.16</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 14
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4xM1w8qR8wgG"
+      },
+      "source": [
+        "## Posterior marginals given dsypnea=present, asia=visit"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "eJJhZFWf70pl",
+        "outputId": "e0d9e318-358f-4426-c447-f5b908b01a46"
+      },
+      "source": [
+        "evidence  = {'dysp': 0, 'asia': 0}\n",
+        "marginals = get_marginals(evidence)\n",
+        "print('\\n')\n",
+        "for k, v in marginals.items():\n",
+        "  print(k, v)\n",
+        "h = visualization(marginals, model)\n",
+        "h"
+      ],
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/pgmpy/factors/discrete/DiscreteFactor.py:519: UserWarning: Found unknown state name. Trying to switch to using all state names as state numbers\n",
+            "  \"Found unknown state name. Trying to switch to using all state names as state numbers\"\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1600.27it/s]\n",
+            "Eliminating: either: 100%|██████████| 5/5 [00:00<00:00, 405.54it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1369.88it/s]\n",
+            "Eliminating: either: 100%|██████████| 5/5 [00:00<00:00, 413.02it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1231.01it/s]\n",
+            "Eliminating: either: 100%|██████████| 5/5 [00:00<00:00, 392.39it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 880.27it/s]\n",
+            "Eliminating: either: 100%|██████████| 5/5 [00:00<00:00, 313.83it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 608.43it/s]\n",
+            "Eliminating: xray: 100%|██████████| 5/5 [00:00<00:00, 346.88it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1398.66it/s]\n",
+            "Eliminating: either: 100%|██████████| 5/5 [00:00<00:00, 344.35it/s]\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "asia 0.0\n",
+            "tub 0.9122490350170781\n",
+            "smoke 0.3740801421787787\n",
+            "lung 0.9004748549054455\n",
+            "bronc 0.1885979284107634\n",
+            "either 0.8177001471772514\n",
+            "xray 0.7804611368748438\n",
+            "dysp 0.0\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7f5bb42a38d0>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: asia_net Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>asia_net</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.91</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.09</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.82</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.18</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.37</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.63</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.90</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.10</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.19</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.81</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.78</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.22</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 15
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hyALNuUaCNza"
+      },
+      "source": [
+        "## Posterior marginals given dsypnea=present, asia=visit, smoking=true"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "gDydpbab9Svz",
+        "outputId": "ae1caea8-c944-4a83-94e8-ad6cdfea29a9"
+      },
+      "source": [
+        "evidence  = {'dysp': 0, 'asia': 0, 'smoke': 0}\n",
+        "marginals = get_marginals(evidence)\n",
+        "print('\\n')\n",
+        "for k, v in marginals.items():\n",
+        "  print(k, v)\n",
+        "h = visualization(marginals, model)\n",
+        "h"
+      ],
+      "execution_count": 16,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/pgmpy/factors/discrete/DiscreteFactor.py:519: UserWarning: Found unknown state name. Trying to switch to using all state names as state numbers\n",
+            "  \"Found unknown state name. Trying to switch to using all state names as state numbers\"\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 694.88it/s]\n",
+            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 397.57it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 1538.07it/s]\n",
+            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 414.84it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 763.47it/s]\n",
+            "Eliminating: lung: 100%|██████████| 4/4 [00:00<00:00, 187.04it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 894.74it/s]\n",
+            "Eliminating: lung: 100%|██████████| 4/4 [00:00<00:00, 329.40it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 826.59it/s]\n",
+            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 375.14it/s]\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "asia 0.0\n",
+            "tub 0.927240461401952\n",
+            "smoke 0.0\n",
+            "lung 0.8544809228039041\n",
+            "bronc 0.13274179236912156\n",
+            "either 0.7889973380656611\n",
+            "xray 0.7537675244010646\n",
+            "dysp 0.0\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7f5bb52ffd50>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: asia_net Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>asia_net</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.93</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.07</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.79</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.21</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.85</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.15</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.13</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.87</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.75</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.25</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 16
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fxLt4NZEHEGp"
+      },
+      "source": [
+        "# Visualization of posterior marginals"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1ZgEQUrOHIyK"
+      },
+      "source": [
+        "\n",
+        "<img src=\"https://user-images.githubusercontent.com/4632336/118872284-40b65700-b89d-11eb-8739-bc94fce6808a.png?raw=true\">\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "C62naP3VJFbV"
+      },
+      "source": [
+        "# Explanatory text from the book.\n",
+        "\n",
+        "In this section,\n",
+        "we consider a hypothetical medical\n",
+        "model proposed in \\citep{Lauritzen88}\n",
+        "which is\n",
+        "known in the literature as the ``\\keywordDef{Asia network}''.\n",
+        "(The name comes  from the fact\n",
+        "that was designed to diagnoise various\n",
+        "lung diseases in Western patients returning from a trip to Asia.\n",
+        "Note that this example predates \n",
+        "the \\COVID pandemic by many years, and is a purely fictitious model.)\n",
+        "\n",
+        "\\cref{fig:pgmAsia1} shows the model, as well as the prior\n",
+        "marginal distributions over each node (assumed to be binary).\n",
+        "Now suppose the patient reports that they have \\keywordDef{Dyspnea},\n",
+        "aka shortness of breath.\n",
+        "We can represent this fact\n",
+        "``clamping'' the distribution to be 100\\% probability\n",
+        "that Dyspnea=Present, and 0\\% probability that Dyspnea=Absent.\n",
+        "We then propagate this new  information  through the network\n",
+        "to get the updated marginal distributions shown in\n",
+        "\\cref{fig:pgmAsia2}.\n",
+        "We see that the probability\n",
+        "of lung cancer has gone up from 5\\% to 10\\%,\n",
+        "and probability of bronchitis has gone up  from 45\\% to 83\\%.\n",
+        "\n",
+        "However, it could also be a an undiagnosed case of TB (tuberculosis),\n",
+        "which may have been caused by exposure to an infectious lung disease\n",
+        "that was prevalent in Asia at the time.\n",
+        "So he doctor asks the patient if they have recently been to Asia,\n",
+        "and they say yes.  \\cref{fig:pgmAsia3} shows the new belief state of each node.\n",
+        "We see that the probability of TB has increased from 2\\% to 9\\%.\n",
+        "However, Bronchitis remains the most likely explanation of the symptoms.\n",
+        "\n",
+        "To gain more information the doctor asks\n",
+        "if the patient smokes, and they say yes.\n",
+        "\\cref{fig:pgmAsia3} shows the new belief state of each node.\n",
+        "Now the probability of cancer and bronchitis have both gone up.\n",
+        "In addition, the posterior predicted probability that an X-ray\n",
+        "will show an abnormal result has gone up to 24\\%, so the doctor may decide\n",
+        "it is now worth ordering a test to verify this hypothesis.\n",
+        "\n",
+        "This example illustrates the nature of recursive Bayesian updating,\n",
+        "and how it can be useful for active learning and sequential decision making,\n",
+        "We will see more examples later in the book."
+      ]
+    }
+  ]
+}

--- a/notebooks/asia_pgm2.ipynb
+++ b/notebooks/asia_pgm2.ipynb
@@ -3,7 +3,7 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "name": "asia_pgm.ipynb",
+      "name": "Copy of asia_pgm.ipynb",
       "provenance": [],
       "toc_visible": true
     },
@@ -46,27 +46,52 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "Ato5RUg5IVjZ"
-      },
-      "source": [
-        ""
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "p4SVMjkpbcJ7"
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "p4SVMjkpbcJ7",
+        "outputId": "b23bc3c6-6918-4786-bf42-49a33ba6b15b"
       },
       "source": [
         "!pip install  causalgraphicalmodels\n",
         "!pip install pgmpy\n",
-        "#!ls /usr/local/lib/python3.7/dist-packages/pgmpy/utils\n",
-        "\n"
+        "#!ls /usr/local/lib/python3.7/dist-packages/pgmpy/utils"
       ],
       "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Requirement already satisfied: causalgraphicalmodels in /usr/local/lib/python3.7/dist-packages (0.0.4)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (2.5.1)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (1.1.5)\n",
+            "Requirement already satisfied: graphviz in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (0.10.1)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (1.19.5)\n",
+            "Requirement already satisfied: decorator<5,>=4.3 in /usr/local/lib/python3.7/dist-packages (from networkx->causalgraphicalmodels) (4.4.2)\n",
+            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.7/dist-packages (from pandas->causalgraphicalmodels) (2.8.1)\n",
+            "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.7/dist-packages (from pandas->causalgraphicalmodels) (2018.9)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.7/dist-packages (from python-dateutil>=2.7.3->pandas->causalgraphicalmodels) (1.15.0)\n",
+            "Requirement already satisfied: pgmpy in /usr/local/lib/python3.7/dist-packages (0.1.14)\n",
+            "Requirement already satisfied: scikit-learn in /usr/local/lib/python3.7/dist-packages (from pgmpy) (0.22.2.post1)\n",
+            "Requirement already satisfied: pyparsing in /usr/local/lib/python3.7/dist-packages (from pgmpy) (2.4.7)\n",
+            "Requirement already satisfied: statsmodels in /usr/local/lib/python3.7/dist-packages (from pgmpy) (0.10.2)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.7/dist-packages (from pgmpy) (2.5.1)\n",
+            "Requirement already satisfied: torch in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.8.1+cu101)\n",
+            "Requirement already satisfied: tqdm in /usr/local/lib/python3.7/dist-packages (from pgmpy) (4.41.1)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.19.5)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.1.5)\n",
+            "Requirement already satisfied: joblib in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.0.1)\n",
+            "Requirement already satisfied: scipy in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.4.1)\n",
+            "Requirement already satisfied: patsy>=0.4.0 in /usr/local/lib/python3.7/dist-packages (from statsmodels->pgmpy) (0.5.1)\n",
+            "Requirement already satisfied: decorator<5,>=4.3 in /usr/local/lib/python3.7/dist-packages (from networkx->pgmpy) (4.4.2)\n",
+            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from torch->pgmpy) (3.7.4.3)\n",
+            "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.7/dist-packages (from pandas->pgmpy) (2018.9)\n",
+            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.7/dist-packages (from pandas->pgmpy) (2.8.1)\n",
+            "Requirement already satisfied: six in /usr/local/lib/python3.7/dist-packages (from patsy>=0.4.0->statsmodels->pgmpy) (1.15.0)\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "code",
@@ -124,7 +149,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "l8xzIiLr0En0"
+        "id": "l8xzIiLr0En0",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "8f2e8d79-0fee-4c0f-9865-627853bb20d9"
       },
       "source": [
         "\n",
@@ -137,24 +166,123 @@
         "model.get_cpds()"
       ],
       "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Nodes:  ['asia', 'tub', 'smoke', 'lung', 'bronc', 'either', 'xray', 'dysp']\n",
+            "Edges:  [('asia', 'tub'), ('tub', 'either'), ('smoke', 'lung'), ('smoke', 'bronc'), ('lung', 'either'), ('bronc', 'dysp'), ('either', 'xray'), ('either', 'dysp')]\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[<TabularCPD representing P(asia:2) at 0x7f9537efced0>,\n",
+              " <TabularCPD representing P(bronc:2 | smoke:2) at 0x7f9537efce50>,\n",
+              " <TabularCPD representing P(dysp:2 | bronc:2, either:2) at 0x7f9537f0a1d0>,\n",
+              " <TabularCPD representing P(either:2 | lung:2, tub:2) at 0x7f9537f0a590>,\n",
+              " <TabularCPD representing P(lung:2 | smoke:2) at 0x7f9537f0a290>,\n",
+              " <TabularCPD representing P(smoke:2) at 0x7f9537f0a850>,\n",
+              " <TabularCPD representing P(tub:2 | asia:2) at 0x7f9537f0a990>,\n",
+              " <TabularCPD representing P(xray:2 | either:2) at 0x7f9537f0ab10>]"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 6
+        }
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "d1GFKz5t5kxA"
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "d1GFKz5t5kxA",
+        "outputId": "e26e8f60-8922-49f7-cbd6-9cd8b4303d87"
       },
       "source": [
         "for c in model.get_cpds():\n",
         "  print(c)"
       ],
       "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "+-----------+------+\n",
+            "| asia(yes) | 0.01 |\n",
+            "+-----------+------+\n",
+            "| asia(no)  | 0.99 |\n",
+            "+-----------+------+\n",
+            "+------------+------------+-----------+\n",
+            "| smoke      | smoke(yes) | smoke(no) |\n",
+            "+------------+------------+-----------+\n",
+            "| bronc(yes) | 0.6        | 0.3       |\n",
+            "+------------+------------+-----------+\n",
+            "| bronc(no)  | 0.4        | 0.7       |\n",
+            "+------------+------------+-----------+\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "| bronc     | bronc(yes)  | bronc(yes) | bronc(no)   | bronc(no)  |\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "| either    | either(yes) | either(no) | either(yes) | either(no) |\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "| dysp(yes) | 0.9         | 0.8        | 0.7         | 0.1        |\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "| dysp(no)  | 0.1         | 0.2        | 0.3         | 0.9        |\n",
+            "+-----------+-------------+------------+-------------+------------+\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "| lung        | lung(yes) | lung(yes) | lung(no) | lung(no) |\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "| tub         | tub(yes)  | tub(no)   | tub(yes) | tub(no)  |\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "| either(yes) | 1.0       | 1.0       | 1.0      | 0.0      |\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "| either(no)  | 0.0       | 0.0       | 0.0      | 1.0      |\n",
+            "+-------------+-----------+-----------+----------+----------+\n",
+            "+-----------+------------+-----------+\n",
+            "| smoke     | smoke(yes) | smoke(no) |\n",
+            "+-----------+------------+-----------+\n",
+            "| lung(yes) | 0.1        | 0.01      |\n",
+            "+-----------+------------+-----------+\n",
+            "| lung(no)  | 0.9        | 0.99      |\n",
+            "+-----------+------------+-----------+\n",
+            "+------------+-----+\n",
+            "| smoke(yes) | 0.5 |\n",
+            "+------------+-----+\n",
+            "| smoke(no)  | 0.5 |\n",
+            "+------------+-----+\n",
+            "+----------+-----------+----------+\n",
+            "| asia     | asia(yes) | asia(no) |\n",
+            "+----------+-----------+----------+\n",
+            "| tub(yes) | 0.05      | 0.01     |\n",
+            "+----------+-----------+----------+\n",
+            "| tub(no)  | 0.95      | 0.99     |\n",
+            "+----------+-----------+----------+\n",
+            "+-----------+-------------+------------+\n",
+            "| either    | either(yes) | either(no) |\n",
+            "+-----------+-------------+------------+\n",
+            "| xray(yes) | 0.98        | 0.05       |\n",
+            "+-----------+-------------+------------+\n",
+            "| xray(no)  | 0.02        | 0.95       |\n",
+            "+-----------+-------------+------------+\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "8jzeJCpE50kw"
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "8jzeJCpE50kw",
+        "outputId": "44e81b76-a31c-44d4-e1f8-b4a47e26c399"
       },
       "source": [
         "asia_cpd = model.get_cpds('asia')\n",
@@ -163,12 +291,29 @@
         "\n"
       ],
       "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "+-----------+------+\n",
+            "| asia(yes) | 0.01 |\n",
+            "+-----------+------+\n",
+            "| asia(no)  | 0.99 |\n",
+            "+-----------+------+\n",
+            "[0.01 0.99]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "VDNdkr0_6TsN"
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "VDNdkr0_6TsN",
+        "outputId": "e73d679c-2e43-4bfd-98fc-fc57cfc1b66f"
       },
       "source": [
         "smoking_cpd = model.get_cpds()[5]\n",
@@ -177,23 +322,53 @@
         "smoking_prior_true = smoking_cpd.values[1]"
       ],
       "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "+------------+-----+\n",
+            "| smoke(yes) | 0.5 |\n",
+            "+------------+-----+\n",
+            "| smoke(no)  | 0.5 |\n",
+            "+------------+-----+\n",
+            "[0.5 0.5]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "YzCS6iizCkIA"
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "YzCS6iizCkIA",
+        "outputId": "daf6c223-0c53-4f1c-f3e9-614f6249f701"
       },
       "source": [
         "print(pgm.get_state_names(model))"
       ],
       "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "{'asia': ['yes', 'no'], 'smoke': ['yes', 'no'], 'bronc': ['yes', 'no'], 'either': ['yes', 'no'], 'dysp': ['yes', 'no'], 'lung': ['yes', 'no'], 'tub': ['yes', 'no'], 'xray': ['yes', 'no']}\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "K8gIy5Bk2XJR"
+        "id": "K8gIy5Bk2XJR",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 385
+        },
+        "outputId": "606354c0-b2f3-4381-adaa-ddba03e56bd4"
       },
       "source": [
         "asia = CausalGraphicalModel(nodes = model.nodes(), edges=model.edges())\n",
@@ -201,6 +376,45 @@
         "out = asia.draw()\n",
         "display(out)\n",
         "out.render()"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7f9537ed3e10>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: %3 Pages: 1 -->\n<svg width=\"196pt\" height=\"260pt\"\n viewBox=\"0.00 0.00 196.50 260.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 256)\">\n<title>%3</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-256 192.4971,-256 192.4971,4 -4,4\"/>\n<!-- dysp -->\n<g id=\"node1\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"36.4971\" cy=\"-18\" rx=\"28.6953\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"36.4971\" y=\"-14.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">dysp</text>\n</g>\n<!-- smoke -->\n<g id=\"node2\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.4971\" cy=\"-234\" rx=\"35.194\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"57.4971\" y=\"-230.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">smoke</text>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"88.4971\" cy=\"-162\" rx=\"27.8951\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"88.4971\" y=\"-158.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">lung</text>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M65.16,-216.2022C68.6888,-208.0064 72.953,-198.1024 76.8659,-189.0145\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"80.1824,-190.162 80.9223,-179.593 73.753,-187.3938 80.1824,-190.162\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"32.4971\" cy=\"-90\" rx=\"32.4942\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"32.4971\" y=\"-86.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">bronc</text>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M54.3814,-216.0535C50.1147,-191.4774 42.4104,-147.1008 37.3751,-118.0974\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"40.8111,-117.4266 35.6521,-108.1727 33.9143,-118.624 40.8111,-117.4266\"/>\n</g>\n<!-- asia -->\n<g id=\"node3\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"161.4971\" cy=\"-234\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"161.4971\" y=\"-230.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">asia</text>\n</g>\n<!-- tub -->\n<g id=\"node8\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"161.4971\" cy=\"-162\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"161.4971\" y=\"-158.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">tub</text>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M161.4971,-215.8314C161.4971,-208.131 161.4971,-198.9743 161.4971,-190.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"164.9972,-190.4132 161.4971,-180.4133 157.9972,-190.4133 164.9972,-190.4132\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"114.4971\" cy=\"-90\" rx=\"31.3957\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"114.4971\" y=\"-86.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">either</text>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M94.9241,-144.2022C97.8304,-136.1541 101.3314,-126.4588 104.5642,-117.5067\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"107.9494,-118.4369 108.054,-107.8425 101.3655,-116.0593 107.9494,-118.4369\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M33.5065,-71.8314C33.9343,-64.131 34.443,-54.9743 34.9184,-46.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"38.414,-46.592 35.4742,-36.4133 31.4248,-46.2037 38.414,-46.592\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M97.9553,-74.7307C87.0236,-64.6398 72.5207,-51.2526 60.3488,-40.0169\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"62.4697,-37.2115 52.7476,-33.0004 57.7217,-42.3551 62.4697,-37.2115\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"114.4971\" cy=\"-18\" rx=\"27.0966\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"114.4971\" y=\"-14.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">xray</text>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M114.4971,-71.8314C114.4971,-64.131 114.4971,-54.9743 114.4971,-46.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"117.9972,-46.4132 114.4971,-36.4133 110.9972,-46.4133 117.9972,-46.4132\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M150.5962,-145.3008C144.8659,-136.5224 137.7166,-125.5703 131.2957,-115.7339\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"134.0624,-113.5693 125.6653,-107.1086 128.2007,-117.3956 134.0624,-113.5693\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          }
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            },
+            "text/plain": [
+              "'Digraph.gv.pdf'"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 11
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "o99fP3xNoPwI"
+      },
+      "source": [
+        "pgm.visualize_model(model)"
       ],
       "execution_count": null,
       "outputs": []
@@ -221,8 +435,7 @@
       },
       "source": [
         "from pgmpy.inference import VariableElimination\n",
-        "infer = VariableElimination(model)\n",
-        "\n"
+        "infer = VariableElimination(model)"
       ],
       "execution_count": null,
       "outputs": []
@@ -239,7 +452,11 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "wIj_U9mC-Q3M"
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "wIj_U9mC-Q3M",
+        "outputId": "c2111b48-ff58-4778-e56a-bb96c50f4b1c"
       },
       "source": [
         "evidence = {}\n",
@@ -252,18 +469,82 @@
         "assert np.allclose(asia_prior, marginals['asia'])"
       ],
       "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1187.08it/s]\n",
+            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 282.78it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1229.07it/s]\n",
+            "Eliminating: smoke: 100%|██████████| 7/7 [00:00<00:00, 235.62it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1545.60it/s]\n",
+            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 311.00it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1322.77it/s]\n",
+            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 230.17it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 2006.71it/s]\n",
+            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 269.39it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1614.52it/s]\n",
+            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 388.88it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 2224.25it/s]\n",
+            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 266.68it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 492.07it/s]\n",
+            "Eliminating: tub: 100%|██████████| 7/7 [00:00<00:00, 354.11it/s]"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "asia [0.01 0.99]\n",
+            "tub [0.0104 0.9896]\n",
+            "smoke [0.5 0.5]\n",
+            "lung [0.055 0.945]\n",
+            "bronc [0.45 0.55]\n",
+            "either [0.064828 0.935172]\n",
+            "xray [0.11029004 0.88970996]\n",
+            "dysp [0.4359706 0.5640294]\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n"
+          ],
+          "name": "stderr"
+        }
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "oC0BWo-PDQU8"
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 785
+        },
+        "id": "oC0BWo-PDQU8",
+        "outputId": "d57daa1d-d22c-4763-d673-81b8506a6718"
       },
       "source": [
-        "display(pgm.visualize_marginals(marginals, model))\n"
+        "pgm.visualize_marginals(marginals, model)"
       ],
       "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7f9537e704d0>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: pgm Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>pgm</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.01</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.99</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.01</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.99</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.06</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.94</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.50</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.50</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.06</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.94</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.45</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.55</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.44</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.56</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"144.4828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.11</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.89</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          }
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -277,17 +558,81 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "ZMcpy_pA67bi"
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "ZMcpy_pA67bi",
+        "outputId": "45e783e2-c0cc-4fbf-8b4b-7e35ed8dac88"
       },
       "source": [
-        "\n",
         "evidence  = {'dysp': 0}\n",
         "marginals = pgm.get_marginals(model, evidence, infer)\n",
         "print('\\n')\n",
         "for k, v in marginals.items():\n",
-        "  print(k, v)\n",
-        "\n",
-        "display(pgm.visualize_marginals(marginals, model))"
+        "  print(k, v)"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/pgmpy/factors/discrete/DiscreteFactor.py:519: UserWarning: Found unknown state name. Trying to switch to using all state names as state numbers\n",
+            "  \"Found unknown state name. Trying to switch to using all state names as state numbers\"\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 2149.64it/s]\n",
+            "Eliminating: tub: 100%|██████████| 6/6 [00:00<00:00, 419.62it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 2181.13it/s]\n",
+            "Eliminating: asia: 100%|██████████| 6/6 [00:00<00:00, 97.14it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1314.28it/s]\n",
+            "Eliminating: tub: 100%|██████████| 6/6 [00:00<00:00, 150.66it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 982.73it/s]\n",
+            "Eliminating: tub: 100%|██████████| 6/6 [00:00<00:00, 363.14it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1535.25it/s]\n",
+            "Eliminating: tub: 100%|██████████| 6/6 [00:00<00:00, 90.77it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1102.75it/s]\n",
+            "Eliminating: tub: 100%|██████████| 6/6 [00:00<00:00, 167.46it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1379.86it/s]\n",
+            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 161.83it/s]\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "asia [0.01032495 0.98967505]\n",
+            "tub [0.01884531 0.98115469]\n",
+            "smoke [0.63399688 0.36600312]\n",
+            "lung [0.10275922 0.89724078]\n",
+            "bronc [0.83396734 0.16603266]\n",
+            "either [0.12053583 0.87946417]\n",
+            "xray [0.16209833 0.83790167]\n",
+            "dysp [1. 0.]\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7f9537647890>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: pgm Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>pgm</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.01</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.99</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.02</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.98</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.12</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.88</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.63</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.37</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.10</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.90</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.83</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.17</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.16</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.84</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "qPsydoXan78S"
+      },
+      "source": [
+        "pgm.visualize_marginals(marginals, model)"
       ],
       "execution_count": null,
       "outputs": []
@@ -304,16 +649,77 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "eJJhZFWf70pl"
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "eJJhZFWf70pl",
+        "outputId": "f791be9a-fdf9-4312-e8c8-775db76249de"
       },
       "source": [
         "evidence  = {'dysp': 'yes', 'asia': 'yes'}\n",
         "marginals = pgm.get_marginals(model,  evidence, infer)\n",
         "print('\\n')\n",
         "for k, v in marginals.items():\n",
-        "  print(k, v)\n",
-        "\n",
-        "display(pgm.visualize_marginals(marginals, model))"
+        "  print(k, v)"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1538.63it/s]\n",
+            "Eliminating: smoke: 100%|██████████| 5/5 [00:00<00:00, 406.24it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 2012.04it/s]\n",
+            "Eliminating: tub: 100%|██████████| 5/5 [00:00<00:00, 355.66it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 466.30it/s]\n",
+            "Eliminating: tub: 100%|██████████| 5/5 [00:00<00:00, 321.76it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1888.65it/s]\n",
+            "Eliminating: tub: 100%|██████████| 5/5 [00:00<00:00, 366.27it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 852.43it/s]\n",
+            "Eliminating: tub: 100%|██████████| 5/5 [00:00<00:00, 376.39it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 461.88it/s]\n",
+            "Eliminating: either: 100%|██████████| 5/5 [00:00<00:00, 268.96it/s]\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "asia [1. 0.]\n",
+            "tub [0.08775096 0.91224904]\n",
+            "smoke [0.62591986 0.37408014]\n",
+            "lung [0.09952515 0.90047485]\n",
+            "bronc [0.81140207 0.18859793]\n",
+            "either [0.18229985 0.81770015]\n",
+            "xray [0.21953886 0.78046114]\n",
+            "dysp [1. 0.]\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7f953763e650>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: pgm Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>pgm</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.09</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.91</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.18</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.82</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.63</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.37</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.10</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.90</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.81</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.19</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.22</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.78</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "8Bn8z4qAn_tw"
+      },
+      "source": [
+        "pgm.visualize_marginals(marginals, model)"
       ],
       "execution_count": null,
       "outputs": []
@@ -330,27 +736,75 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "gDydpbab9Svz"
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "gDydpbab9Svz",
+        "outputId": "7bf2565a-b243-4867-ab6d-b4cc3005ed26"
       },
       "source": [
         "evidence  = {'dysp': 'yes', 'asia': 'yes', 'smoke': 'yes'}\n",
         "marginals = pgm.get_marginals(model, evidence, infer)\n",
         "print('\\n')\n",
         "for k, v in marginals.items():\n",
-        "  print(k, v)\n",
-        "\n",
-        "display(pgm.visualize_marginals(marginals, model))"
+        "  print(k, v)"
       ],
       "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 424.42it/s]\n",
+            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 198.50it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 184.01it/s]\n",
+            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 176.03it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 723.90it/s]\n",
+            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 234.53it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 573.97it/s]\n",
+            "Eliminating: xray: 100%|██████████| 4/4 [00:00<00:00, 288.49it/s]\n",
+            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 688.27it/s]\n",
+            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 176.36it/s]\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            "\n",
+            "asia [1. 0.]\n",
+            "tub [0.07275954 0.92724046]\n",
+            "smoke [1. 0.]\n",
+            "lung [0.14551908 0.85448092]\n",
+            "bronc [0.86725821 0.13274179]\n",
+            "either [0.21100266 0.78899734]\n",
+            "xray [0.24623248 0.75376752]\n",
+            "dysp [1. 0.]\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<graphviz.dot.Digraph at 0x7f95376646d0>"
+            ],
+            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: pgm Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>pgm</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.07</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.93</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.21</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.79</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.15</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.85</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.87</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.13</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.25</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.75</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
+          },
+          "metadata": {
+            "tags": []
+          }
+        }
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "24L0MlUXCgDw"
+        "id": "TThGsdvgoC8b"
       },
       "source": [
-        ""
+        "pgm.visualize_marginals(marginals, model)"
       ],
       "execution_count": null,
       "outputs": []

--- a/notebooks/asia_pgm2.ipynb
+++ b/notebooks/asia_pgm2.ipynb
@@ -3,7 +3,7 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "name": "Copy of asia_pgm.ipynb",
+      "name": "asia_pgm.ipynb",
       "provenance": [],
       "toc_visible": true
     },
@@ -31,60 +31,42 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "p4SVMjkpbcJ7",
-        "outputId": "56637954-ef6c-417e-f213-cd4faac87d3d"
+        "id": "G1TmpsRLINLR"
+      },
+      "source": [
+        "!git clone https://github.com/probml/pyprobml /pyprobml &> /dev/null\n",
+        "%cd -q /pyprobml/scripts\n",
+        "import pyprobml_utils as pml\n",
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Ato5RUg5IVjZ"
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "p4SVMjkpbcJ7"
       },
       "source": [
         "!pip install  causalgraphicalmodels\n",
         "!pip install pgmpy\n",
-        "\n",
-        "#!ls /usr/local/lib/python3.7/dist-packages/pgmpy/utils"
+        "#!ls /usr/local/lib/python3.7/dist-packages/pgmpy/utils\n",
+        "\n"
       ],
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Collecting causalgraphicalmodels\n",
-            "  Downloading https://files.pythonhosted.org/packages/c8/ee/3b2d184576f3cb4873cebfc696e8e5c1e53eaef691f38aea76c206f9f916/causalgraphicalmodels-0.0.4-py3-none-any.whl\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (1.19.5)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (2.5.1)\n",
-            "Requirement already satisfied: pandas in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (1.1.5)\n",
-            "Requirement already satisfied: graphviz in /usr/local/lib/python3.7/dist-packages (from causalgraphicalmodels) (0.10.1)\n",
-            "Requirement already satisfied: decorator<5,>=4.3 in /usr/local/lib/python3.7/dist-packages (from networkx->causalgraphicalmodels) (4.4.2)\n",
-            "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.7/dist-packages (from pandas->causalgraphicalmodels) (2018.9)\n",
-            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.7/dist-packages (from pandas->causalgraphicalmodels) (2.8.1)\n",
-            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.7/dist-packages (from python-dateutil>=2.7.3->pandas->causalgraphicalmodels) (1.15.0)\n",
-            "Installing collected packages: causalgraphicalmodels\n",
-            "Successfully installed causalgraphicalmodels-0.0.4\n",
-            "Collecting pgmpy\n",
-            "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/a3/0e/d9fadbfaa35e010c04d43acd3ae9fbefec98897dd7d61a6b7eb5a8b34072/pgmpy-0.1.14-py3-none-any.whl (331kB)\n",
-            "\u001b[K     |████████████████████████████████| 337kB 8.0MB/s \n",
-            "\u001b[?25hRequirement already satisfied: scikit-learn in /usr/local/lib/python3.7/dist-packages (from pgmpy) (0.22.2.post1)\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.19.5)\n",
-            "Requirement already satisfied: scipy in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.4.1)\n",
-            "Requirement already satisfied: torch in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.8.1+cu101)\n",
-            "Requirement already satisfied: pandas in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.1.5)\n",
-            "Requirement already satisfied: pyparsing in /usr/local/lib/python3.7/dist-packages (from pgmpy) (2.4.7)\n",
-            "Requirement already satisfied: joblib in /usr/local/lib/python3.7/dist-packages (from pgmpy) (1.0.1)\n",
-            "Requirement already satisfied: tqdm in /usr/local/lib/python3.7/dist-packages (from pgmpy) (4.41.1)\n",
-            "Requirement already satisfied: networkx in /usr/local/lib/python3.7/dist-packages (from pgmpy) (2.5.1)\n",
-            "Requirement already satisfied: statsmodels in /usr/local/lib/python3.7/dist-packages (from pgmpy) (0.10.2)\n",
-            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from torch->pgmpy) (3.7.4.3)\n",
-            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.7/dist-packages (from pandas->pgmpy) (2.8.1)\n",
-            "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.7/dist-packages (from pandas->pgmpy) (2018.9)\n",
-            "Requirement already satisfied: decorator<5,>=4.3 in /usr/local/lib/python3.7/dist-packages (from networkx->pgmpy) (4.4.2)\n",
-            "Requirement already satisfied: patsy>=0.4.0 in /usr/local/lib/python3.7/dist-packages (from statsmodels->pgmpy) (0.5.1)\n",
-            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.7/dist-packages (from python-dateutil>=2.7.3->pandas->pgmpy) (1.15.0)\n",
-            "Installing collected packages: pgmpy\n",
-            "Successfully installed pgmpy-0.1.14\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -96,9 +78,11 @@
         "import pgmpy\n",
         "import numpy as np\n",
         "import pandas as pd\n",
-        "from graphviz import Digraph"
+        "from graphviz import Digraph\n",
+        "\n",
+        "import pgmpy_utils as pgm # from pyprobml\n"
       ],
-      "execution_count": 2,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -120,7 +104,7 @@
         "#asia = get_example_model('asia')\n",
         "# No such file or directory: 'pgmpy/utils/example_models/asia.bif.gz'"
       ],
-      "execution_count": 3,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -134,19 +118,16 @@
         "!wget https://www.bnlearn.com/bnrepository/asia/asia.bif.gz -q -O asia.bif.gz\n",
         "!gunzip asia.bif.gz"
       ],
-      "execution_count": 4,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "l8xzIiLr0En0",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "7ed97f8a-3d40-4f20-caf1-41a707e6c35f"
+        "id": "l8xzIiLr0En0"
       },
       "source": [
+        "\n",
         "from pgmpy.readwrite import BIFReader, BIFWriter\n",
         "reader = BIFReader(\"asia.bif\")\n",
         "model = reader.get_model()\n",
@@ -155,155 +136,39 @@
         "print(\"Edges: \", model.edges())\n",
         "model.get_cpds()"
       ],
-      "execution_count": 5,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Nodes:  ['asia', 'tub', 'smoke', 'lung', 'bronc', 'either', 'xray', 'dysp']\n",
-            "Edges:  [('asia', 'tub'), ('tub', 'either'), ('smoke', 'lung'), ('smoke', 'bronc'), ('lung', 'either'), ('bronc', 'dysp'), ('either', 'xray'), ('either', 'dysp')]\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "[<TabularCPD representing P(asia:2) at 0x7f5bb534f090>,\n",
-              " <TabularCPD representing P(bronc:2 | smoke:2) at 0x7f5bb59f3950>,\n",
-              " <TabularCPD representing P(dysp:2 | bronc:2, either:2) at 0x7f5bb6a11c10>,\n",
-              " <TabularCPD representing P(either:2 | lung:2, tub:2) at 0x7f5bb53c4f90>,\n",
-              " <TabularCPD representing P(lung:2 | smoke:2) at 0x7f5bb5355bd0>,\n",
-              " <TabularCPD representing P(smoke:2) at 0x7f5bb5355e10>,\n",
-              " <TabularCPD representing P(tub:2 | asia:2) at 0x7f5bb5355a90>,\n",
-              " <TabularCPD representing P(xray:2 | either:2) at 0x7f5bb5355c90>]"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 5
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "d1GFKz5t5kxA",
-        "outputId": "1affbcfd-c535-45c7-a5db-fce1530886cf"
+        "id": "d1GFKz5t5kxA"
       },
       "source": [
         "for c in model.get_cpds():\n",
         "  print(c)"
       ],
-      "execution_count": 6,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "+-----------+------+\n",
-            "| asia(yes) | 0.01 |\n",
-            "+-----------+------+\n",
-            "| asia(no)  | 0.99 |\n",
-            "+-----------+------+\n",
-            "+------------+------------+-----------+\n",
-            "| smoke      | smoke(yes) | smoke(no) |\n",
-            "+------------+------------+-----------+\n",
-            "| bronc(yes) | 0.6        | 0.3       |\n",
-            "+------------+------------+-----------+\n",
-            "| bronc(no)  | 0.4        | 0.7       |\n",
-            "+------------+------------+-----------+\n",
-            "+-----------+-------------+------------+-------------+------------+\n",
-            "| bronc     | bronc(yes)  | bronc(yes) | bronc(no)   | bronc(no)  |\n",
-            "+-----------+-------------+------------+-------------+------------+\n",
-            "| either    | either(yes) | either(no) | either(yes) | either(no) |\n",
-            "+-----------+-------------+------------+-------------+------------+\n",
-            "| dysp(yes) | 0.9         | 0.8        | 0.7         | 0.1        |\n",
-            "+-----------+-------------+------------+-------------+------------+\n",
-            "| dysp(no)  | 0.1         | 0.2        | 0.3         | 0.9        |\n",
-            "+-----------+-------------+------------+-------------+------------+\n",
-            "+-------------+-----------+-----------+----------+----------+\n",
-            "| lung        | lung(yes) | lung(yes) | lung(no) | lung(no) |\n",
-            "+-------------+-----------+-----------+----------+----------+\n",
-            "| tub         | tub(yes)  | tub(no)   | tub(yes) | tub(no)  |\n",
-            "+-------------+-----------+-----------+----------+----------+\n",
-            "| either(yes) | 1.0       | 1.0       | 1.0      | 0.0      |\n",
-            "+-------------+-----------+-----------+----------+----------+\n",
-            "| either(no)  | 0.0       | 0.0       | 0.0      | 1.0      |\n",
-            "+-------------+-----------+-----------+----------+----------+\n",
-            "+-----------+------------+-----------+\n",
-            "| smoke     | smoke(yes) | smoke(no) |\n",
-            "+-----------+------------+-----------+\n",
-            "| lung(yes) | 0.1        | 0.01      |\n",
-            "+-----------+------------+-----------+\n",
-            "| lung(no)  | 0.9        | 0.99      |\n",
-            "+-----------+------------+-----------+\n",
-            "+------------+-----+\n",
-            "| smoke(yes) | 0.5 |\n",
-            "+------------+-----+\n",
-            "| smoke(no)  | 0.5 |\n",
-            "+------------+-----+\n",
-            "+----------+-----------+----------+\n",
-            "| asia     | asia(yes) | asia(no) |\n",
-            "+----------+-----------+----------+\n",
-            "| tub(yes) | 0.05      | 0.01     |\n",
-            "+----------+-----------+----------+\n",
-            "| tub(no)  | 0.95      | 0.99     |\n",
-            "+----------+-----------+----------+\n",
-            "+-----------+-------------+------------+\n",
-            "| either    | either(yes) | either(no) |\n",
-            "+-----------+-------------+------------+\n",
-            "| xray(yes) | 0.98        | 0.05       |\n",
-            "+-----------+-------------+------------+\n",
-            "| xray(no)  | 0.02        | 0.95       |\n",
-            "+-----------+-------------+------------+\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "8jzeJCpE50kw",
-        "outputId": "f8d0f222-e7fb-4a05-a8a7-26c2c879b9c5"
+        "id": "8jzeJCpE50kw"
       },
       "source": [
-        "asia_cpd = model.get_cpds()[0]\n",
+        "asia_cpd = model.get_cpds('asia')\n",
         "print(asia_cpd)\n",
         "print(asia_cpd.values)\n",
-        "asia_prior_true = asia_cpd.values[1]"
+        "\n"
       ],
-      "execution_count": 7,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "+-----------+------+\n",
-            "| asia(yes) | 0.01 |\n",
-            "+-----------+------+\n",
-            "| asia(no)  | 0.99 |\n",
-            "+-----------+------+\n",
-            "[0.01 0.99]\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "VDNdkr0_6TsN",
-        "outputId": "985ac72a-a1f8-4144-ef84-4bf2fbfafc18"
+        "id": "VDNdkr0_6TsN"
       },
       "source": [
         "smoking_cpd = model.get_cpds()[5]\n",
@@ -311,74 +176,39 @@
         "print(smoking_cpd.values)\n",
         "smoking_prior_true = smoking_cpd.values[1]"
       ],
-      "execution_count": 8,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "+------------+-----+\n",
-            "| smoke(yes) | 0.5 |\n",
-            "+------------+-----+\n",
-            "| smoke(no)  | 0.5 |\n",
-            "+------------+-----+\n",
-            "[0.5 0.5]\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "K8gIy5Bk2XJR",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 388
-        },
-        "outputId": "61f875e9-925f-45b5-fb0b-85f67b01b1a6"
+        "id": "YzCS6iizCkIA"
+      },
+      "source": [
+        "print(pgm.get_state_names(model))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "K8gIy5Bk2XJR"
       },
       "source": [
         "asia = CausalGraphicalModel(nodes = model.nodes(), edges=model.edges())\n",
-        "nodes = model.nodes()\n",
+        "\n",
         "out = asia.draw()\n",
         "display(out)\n",
         "out.render()"
       ],
-      "execution_count": 9,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<graphviz.dot.Digraph at 0x7f5bb531f8d0>"
-            ],
-            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: %3 Pages: 1 -->\n<svg width=\"196pt\" height=\"260pt\"\n viewBox=\"0.00 0.00 196.50 260.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 256)\">\n<title>%3</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-256 192.4971,-256 192.4971,4 -4,4\"/>\n<!-- tub -->\n<g id=\"node1\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"161.4971\" cy=\"-162\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"161.4971\" y=\"-158.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">tub</text>\n</g>\n<!-- either -->\n<g id=\"node5\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"114.4971\" cy=\"-90\" rx=\"31.3957\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"114.4971\" y=\"-86.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">either</text>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M150.5962,-145.3008C144.8659,-136.5224 137.7166,-125.5703 131.2957,-115.7339\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"134.0624,-113.5693 125.6653,-107.1086 128.2007,-117.3956 134.0624,-113.5693\"/>\n</g>\n<!-- lung -->\n<g id=\"node2\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"88.4971\" cy=\"-162\" rx=\"27.8951\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"88.4971\" y=\"-158.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">lung</text>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M94.9241,-144.2022C97.8304,-136.1541 101.3314,-126.4588 104.5642,-117.5067\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"107.9494,-118.4369 108.054,-107.8425 101.3655,-116.0593 107.9494,-118.4369\"/>\n</g>\n<!-- asia -->\n<g id=\"node3\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"161.4971\" cy=\"-234\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"161.4971\" y=\"-230.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">asia</text>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M161.4971,-215.8314C161.4971,-208.131 161.4971,-198.9743 161.4971,-190.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"164.9972,-190.4132 161.4971,-180.4133 157.9972,-190.4133 164.9972,-190.4132\"/>\n</g>\n<!-- xray -->\n<g id=\"node4\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"114.4971\" cy=\"-18\" rx=\"27.0966\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"114.4971\" y=\"-14.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">xray</text>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M114.4971,-71.8314C114.4971,-64.131 114.4971,-54.9743 114.4971,-46.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"117.9972,-46.4132 114.4971,-36.4133 110.9972,-46.4133 117.9972,-46.4132\"/>\n</g>\n<!-- dysp -->\n<g id=\"node6\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"36.4971\" cy=\"-18\" rx=\"28.6953\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"36.4971\" y=\"-14.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">dysp</text>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M97.9553,-74.7307C87.0236,-64.6398 72.5207,-51.2526 60.3488,-40.0169\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"62.4697,-37.2115 52.7476,-33.0004 57.7217,-42.3551 62.4697,-37.2115\"/>\n</g>\n<!-- bronc -->\n<g id=\"node7\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"32.4971\" cy=\"-90\" rx=\"32.4942\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"32.4971\" y=\"-86.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">bronc</text>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M33.5065,-71.8314C33.9343,-64.131 34.443,-54.9743 34.9184,-46.4166\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"38.414,-46.592 35.4742,-36.4133 31.4248,-46.2037 38.414,-46.592\"/>\n</g>\n<!-- smoke -->\n<g id=\"node8\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.4971\" cy=\"-234\" rx=\"35.194\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"57.4971\" y=\"-230.3\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">smoke</text>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M65.16,-216.2022C68.6888,-208.0064 72.953,-198.1024 76.8659,-189.0145\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"80.1824,-190.162 80.9223,-179.593 73.753,-187.3938 80.1824,-190.162\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M54.3814,-216.0535C50.1147,-191.4774 42.4104,-147.1008 37.3751,-118.0974\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"40.8111,-117.4266 35.6521,-108.1727 33.9143,-118.624 40.8111,-117.4266\"/>\n</g>\n</g>\n</svg>\n"
-          },
-          "metadata": {
-            "tags": []
-          }
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'Digraph.gv.pdf'"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 9
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "3s_MxAup4Ol2"
+        "id": "5FyYbZfmD-AV"
       },
       "source": [
         "# Inference"
@@ -391,70 +221,10 @@
       },
       "source": [
         "from pgmpy.inference import VariableElimination\n",
-        "infer = VariableElimination(model)"
+        "infer = VariableElimination(model)\n",
+        "\n"
       ],
-      "execution_count": 10,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "RENNeAKA9nbj"
-      },
-      "source": [
-        "def get_marginals(evidence = {}):\n",
-        "  nodes = model.nodes()\n",
-        "  num_nodes = len(nodes)\n",
-        "  marginals = dict()\n",
-        "  for n in nodes:\n",
-        "    if n in evidence: # observed nodes\n",
-        "      v = evidence[n]\n",
-        "      if v == 1:      \n",
-        "        marginals[n] = 1.0 # clamped to state 1\n",
-        "      else:\n",
-        "        marginals[n] = 0.0 # clamped to state 0\n",
-        "    else:\n",
-        "      probs = infer.query([n], evidence=evidence).values\n",
-        "      marginals[n] = probs[1] # probability in state 1\n",
-        "  return marginals\n"
-      ],
-      "execution_count": 11,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "r1_t_YvN0XwF"
-      },
-      "source": [
-        "def visualization(marginals, model):\n",
-        "  h = Digraph('asia_net')\n",
-        "  titles = list(marginals.keys())\n",
-        "  yes_prob = list(marginals.values())\n",
-        "  no_prob = [1 - x for x in yes_prob]\n",
-        "  for i in range(len(marginals)):\n",
-        "    h.node(titles[i], label='''<<TABLE>\n",
-        "      <TR PORT=\"header\">\n",
-        "          <TD BGCOLOR=\"#d23939\" COLSPAN=\"2\"> {} </TD>\n",
-        "      </TR>\n",
-        "      <TR>\n",
-        "        <TD>yes</TD>\n",
-        "        <TD>{:.2f}</TD>\n",
-        "      </TR>\n",
-        "      <TR>\n",
-        "        <TD>no</TD>\n",
-        "        <TD>{:.2f}</TD>\n",
-        "      </TR>\n",
-        "    </TABLE>>'''.format(titles[i], yes_prob[i], no_prob[i]))\n",
-        "\n",
-        "  edges = (model.edges())\n",
-        "  for item in edges:\n",
-        "    edge = list(item)\n",
-        "    h.edge(edge[0], edge[1])\n",
-        "  \n",
-        "  return h\n"
-      ],
-      "execution_count": 12,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -469,73 +239,31 @@
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "id": "wIj_U9mC-Q3M",
-        "outputId": "6ef551bf-acee-4612-ea2d-5ff3af30824b"
+        "id": "wIj_U9mC-Q3M"
       },
       "source": [
-        "marginals = get_marginals()\n",
+        "evidence = {}\n",
+        "marginals = pgm.get_marginals(model, evidence)\n",
+        "print('\\n')\n",
         "for k, v in marginals.items():\n",
         "  print(k, v)\n",
-        "assert np.allclose(asia_prior_true, marginals['asia']) #Asia (0.5, 0.5)\n",
-        "h = visualization(marginals, model)\n",
-        "h"
+        "\n",
+        "asia_prior = model.get_cpds('asia').values\n",
+        "assert np.allclose(asia_prior, marginals['asia'])"
       ],
-      "execution_count": 13,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1424.56it/s]\n",
-            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 259.84it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1044.36it/s]\n",
-            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 236.92it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 917.91it/s]\n",
-            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 253.14it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 2309.64it/s]\n",
-            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 369.69it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 2028.05it/s]\n",
-            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 379.30it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 1937.71it/s]\n",
-            "Eliminating: xray: 100%|██████████| 7/7 [00:00<00:00, 277.38it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 878.73it/s]\n",
-            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 261.39it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 7/7 [00:00<00:00, 2573.19it/s]\n",
-            "Eliminating: either: 100%|██████████| 7/7 [00:00<00:00, 325.55it/s]\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "asia 0.99\n",
-            "tub 0.9896\n",
-            "smoke 0.49999999999999994\n",
-            "lung 0.945\n",
-            "bronc 0.55\n",
-            "either 0.935172\n",
-            "xray 0.88970996\n",
-            "dysp 0.5640294\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<graphviz.dot.Digraph at 0x7f5bb5300f90>"
-            ],
-            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: asia_net Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>asia_net</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.99</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.01</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.99</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.01</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.94</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.06</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.50</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.50</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.94</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.06</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.55</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.45</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.56</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.44</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.89</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"144.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.11</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 13
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "oC0BWo-PDQU8"
+      },
+      "source": [
+        "display(pgm.visualize_marginals(marginals, model))\n"
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -543,82 +271,26 @@
         "id": "StB-XG1z7FEP"
       },
       "source": [
-        "## Posterior marginals given dsypnea=present"
+        "## Posterior marginals given dsypnea=yes"
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "id": "ZMcpy_pA67bi",
-        "outputId": "ea928d8a-3a5b-47fe-c724-7b8992622d81"
+        "id": "ZMcpy_pA67bi"
       },
       "source": [
+        "\n",
         "evidence  = {'dysp': 0}\n",
-        "marginals = get_marginals(evidence)\n",
+        "marginals = pgm.get_marginals(model, evidence, infer)\n",
         "print('\\n')\n",
         "for k, v in marginals.items():\n",
         "  print(k, v)\n",
-        "h = visualization(marginals, model)\n",
-        "h"
+        "\n",
+        "display(pgm.visualize_marginals(marginals, model))"
       ],
-      "execution_count": 14,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "/usr/local/lib/python3.7/dist-packages/pgmpy/factors/discrete/DiscreteFactor.py:519: UserWarning: Found unknown state name. Trying to switch to using all state names as state numbers\n",
-            "  \"Found unknown state name. Trying to switch to using all state names as state numbers\"\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1096.84it/s]\n",
-            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 313.34it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1172.63it/s]\n",
-            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 310.75it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1788.74it/s]\n",
-            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 251.74it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1333.64it/s]\n",
-            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 220.39it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 776.51it/s]\n",
-            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 248.01it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1301.77it/s]\n",
-            "Eliminating: xray: 100%|██████████| 6/6 [00:00<00:00, 252.02it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 6/6 [00:00<00:00, 1831.57it/s]\n",
-            "Eliminating: either: 100%|██████████| 6/6 [00:00<00:00, 261.85it/s]\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "\n",
-            "asia 0.9896750491890968\n",
-            "tub 0.9811546925411943\n",
-            "smoke 0.3660031203938981\n",
-            "lung 0.8972407772450711\n",
-            "bronc 0.1660326636704402\n",
-            "either 0.8794641657029166\n",
-            "xray 0.8379016741037125\n",
-            "dysp 0.0\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<graphviz.dot.Digraph at 0x7f5bb5345bd0>"
-            ],
-            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: asia_net Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>asia_net</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.99</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.01</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.98</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.02</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.88</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.12</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.37</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.63</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.90</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.10</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.17</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.83</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.84</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.16</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 14
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -626,80 +298,25 @@
         "id": "4xM1w8qR8wgG"
       },
       "source": [
-        "## Posterior marginals given dsypnea=present, asia=visit"
+        "## Posterior marginals given dsypnea=yes, asia=yes"
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "id": "eJJhZFWf70pl",
-        "outputId": "e0d9e318-358f-4426-c447-f5b908b01a46"
+        "id": "eJJhZFWf70pl"
       },
       "source": [
-        "evidence  = {'dysp': 0, 'asia': 0}\n",
-        "marginals = get_marginals(evidence)\n",
+        "evidence  = {'dysp': 'yes', 'asia': 'yes'}\n",
+        "marginals = pgm.get_marginals(model,  evidence, infer)\n",
         "print('\\n')\n",
         "for k, v in marginals.items():\n",
         "  print(k, v)\n",
-        "h = visualization(marginals, model)\n",
-        "h"
+        "\n",
+        "display(pgm.visualize_marginals(marginals, model))"
       ],
-      "execution_count": 15,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "/usr/local/lib/python3.7/dist-packages/pgmpy/factors/discrete/DiscreteFactor.py:519: UserWarning: Found unknown state name. Trying to switch to using all state names as state numbers\n",
-            "  \"Found unknown state name. Trying to switch to using all state names as state numbers\"\n",
-            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1600.27it/s]\n",
-            "Eliminating: either: 100%|██████████| 5/5 [00:00<00:00, 405.54it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1369.88it/s]\n",
-            "Eliminating: either: 100%|██████████| 5/5 [00:00<00:00, 413.02it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1231.01it/s]\n",
-            "Eliminating: either: 100%|██████████| 5/5 [00:00<00:00, 392.39it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 880.27it/s]\n",
-            "Eliminating: either: 100%|██████████| 5/5 [00:00<00:00, 313.83it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 608.43it/s]\n",
-            "Eliminating: xray: 100%|██████████| 5/5 [00:00<00:00, 346.88it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 5/5 [00:00<00:00, 1398.66it/s]\n",
-            "Eliminating: either: 100%|██████████| 5/5 [00:00<00:00, 344.35it/s]\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "\n",
-            "asia 0.0\n",
-            "tub 0.9122490350170781\n",
-            "smoke 0.3740801421787787\n",
-            "lung 0.9004748549054455\n",
-            "bronc 0.1885979284107634\n",
-            "either 0.8177001471772514\n",
-            "xray 0.7804611368748438\n",
-            "dysp 0.0\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<graphviz.dot.Digraph at 0x7f5bb42a38d0>"
-            ],
-            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: asia_net Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>asia_net</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.91</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.09</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.82</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.18</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.37</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.63</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.90</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.10</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.19</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.81</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.78</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.22</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 15
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -707,152 +324,36 @@
         "id": "hyALNuUaCNza"
       },
       "source": [
-        "## Posterior marginals given dsypnea=present, asia=visit, smoking=true"
+        "## Posterior marginals given dsypnea=yes, asia=yes, smoking=yes"
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1000
-        },
-        "id": "gDydpbab9Svz",
-        "outputId": "ae1caea8-c944-4a83-94e8-ad6cdfea29a9"
+        "id": "gDydpbab9Svz"
       },
       "source": [
-        "evidence  = {'dysp': 0, 'asia': 0, 'smoke': 0}\n",
-        "marginals = get_marginals(evidence)\n",
+        "evidence  = {'dysp': 'yes', 'asia': 'yes', 'smoke': 'yes'}\n",
+        "marginals = pgm.get_marginals(model, evidence, infer)\n",
         "print('\\n')\n",
         "for k, v in marginals.items():\n",
         "  print(k, v)\n",
-        "h = visualization(marginals, model)\n",
-        "h"
+        "\n",
+        "display(pgm.visualize_marginals(marginals, model))"
       ],
-      "execution_count": 16,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "/usr/local/lib/python3.7/dist-packages/pgmpy/factors/discrete/DiscreteFactor.py:519: UserWarning: Found unknown state name. Trying to switch to using all state names as state numbers\n",
-            "  \"Found unknown state name. Trying to switch to using all state names as state numbers\"\n",
-            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 694.88it/s]\n",
-            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 397.57it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 1538.07it/s]\n",
-            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 414.84it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 763.47it/s]\n",
-            "Eliminating: lung: 100%|██████████| 4/4 [00:00<00:00, 187.04it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 894.74it/s]\n",
-            "Eliminating: lung: 100%|██████████| 4/4 [00:00<00:00, 329.40it/s]\n",
-            "Finding Elimination Order: : 100%|██████████| 4/4 [00:00<00:00, 826.59it/s]\n",
-            "Eliminating: either: 100%|██████████| 4/4 [00:00<00:00, 375.14it/s]\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "\n",
-            "asia 0.0\n",
-            "tub 0.927240461401952\n",
-            "smoke 0.0\n",
-            "lung 0.8544809228039041\n",
-            "bronc 0.13274179236912156\n",
-            "either 0.7889973380656611\n",
-            "xray 0.7537675244010646\n",
-            "dysp 0.0\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<graphviz.dot.Digraph at 0x7f5bb52ffd50>"
-            ],
-            "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 2.40.1 (20161225.0304)\n -->\n<!-- Title: asia_net Pages: 1 -->\n<svg width=\"344pt\" height=\"574pt\"\n viewBox=\"0.00 0.00 343.97 574.21\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 570.2052)\">\n<title>asia_net</title>\n<polygon fill=\"#ffffff\" stroke=\"transparent\" points=\"-4,4 -4,-570.2052 339.9655,-570.2052 339.9655,4 -4,4\"/>\n<!-- asia -->\n<g id=\"node1\" class=\"node\">\n<title>asia</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-520.9295 27.9828,-541.9295 87.9828,-541.9295 87.9828,-520.9295 27.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"43.4828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> asia </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-497.9295 27.9828,-518.9295 52.9828,-518.9295 52.9828,-497.9295 27.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-497.9295 54.9828,-518.9295 87.9828,-518.9295 87.9828,-497.9295 54.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-474.9295 27.9828,-495.9295 52.9828,-495.9295 52.9828,-474.9295 27.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-474.9295 54.9828,-495.9295 87.9828,-495.9295 87.9828,-474.9295 54.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-472.4295 24.9828,-545.4295 90.9828,-545.4295 90.9828,-472.4295 24.9828,-472.4295\"/>\n</g>\n<!-- tub -->\n<g id=\"node2\" class=\"node\">\n<title>tub</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"57.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-370.3782 27.9828,-391.3782 87.9828,-391.3782 87.9828,-370.3782 27.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"44.4828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> tub </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-347.3782 27.9828,-368.3782 52.9828,-368.3782 52.9828,-347.3782 27.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"30.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-347.3782 54.9828,-368.3782 87.9828,-368.3782 87.9828,-347.3782 54.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.93</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"27.9828,-324.3782 27.9828,-345.3782 52.9828,-345.3782 52.9828,-324.3782 27.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"32.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"54.9828,-324.3782 54.9828,-345.3782 87.9828,-345.3782 87.9828,-324.3782 54.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"57.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.07</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"24.9828,-321.8782 24.9828,-394.8782 90.9828,-394.8782 90.9828,-321.8782 24.9828,-321.8782\"/>\n</g>\n<!-- asia&#45;&gt;tub -->\n<g id=\"edge1\" class=\"edge\">\n<title>asia&#45;&gt;tub</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M57.9828,-451.5831C57.9828,-443.3123 57.9828,-434.7349 57.9828,-426.2827\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"61.4829,-426.064 57.9828,-416.064 54.4829,-426.064 61.4829,-426.064\"/>\n</g>\n<!-- either -->\n<g id=\"node6\" class=\"node\">\n<title>either</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-219.8269 113.9828,-240.8269 173.9828,-240.8269 173.9828,-219.8269 113.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"123.9828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> either </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-196.8269 113.9828,-217.8269 138.9828,-217.8269 138.9828,-196.8269 113.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-196.8269 140.9828,-217.8269 173.9828,-217.8269 173.9828,-196.8269 140.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.79</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-173.8269 113.9828,-194.8269 138.9828,-194.8269 138.9828,-173.8269 113.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-173.8269 140.9828,-194.8269 173.9828,-194.8269 173.9828,-173.8269 140.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.21</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-171.3269 110.9828,-244.3269 176.9828,-244.3269 176.9828,-171.3269 110.9828,-171.3269\"/>\n</g>\n<!-- tub&#45;&gt;either -->\n<g id=\"edge2\" class=\"edge\">\n<title>tub&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M86.6195,-308.2468C94.2351,-294.9149 102.5299,-280.3942 110.3845,-266.6439\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"113.55,-268.1587 115.4711,-257.7394 107.4718,-264.6866 113.55,-268.1587\"/>\n</g>\n<!-- smoke -->\n<g id=\"node3\" class=\"node\">\n<title>smoke</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"234.9828\" cy=\"-508.9295\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-520.9295 204.9828,-541.9295 264.9828,-541.9295 264.9828,-520.9295 204.9828,-520.9295\"/>\n<text text-anchor=\"start\" x=\"211.9828\" y=\"-527.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> smoke </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-497.9295 204.9828,-518.9295 229.9828,-518.9295 229.9828,-497.9295 204.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"207.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-497.9295 231.9828,-518.9295 264.9828,-518.9295 264.9828,-497.9295 231.9828,-497.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-504.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"204.9828,-474.9295 204.9828,-495.9295 229.9828,-495.9295 229.9828,-474.9295 204.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"209.4828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"231.9828,-474.9295 231.9828,-495.9295 264.9828,-495.9295 264.9828,-474.9295 231.9828,-474.9295\"/>\n<text text-anchor=\"start\" x=\"234.9828\" y=\"-481.7295\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"201.9828,-472.4295 201.9828,-545.4295 267.9828,-545.4295 267.9828,-472.4295 201.9828,-472.4295\"/>\n</g>\n<!-- lung -->\n<g id=\"node4\" class=\"node\">\n<title>lung</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"191.9828\" cy=\"-358.3782\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-370.3782 161.9828,-391.3782 221.9828,-391.3782 221.9828,-370.3782 161.9828,-370.3782\"/>\n<text text-anchor=\"start\" x=\"174.9828\" y=\"-377.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> lung </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-347.3782 161.9828,-368.3782 186.9828,-368.3782 186.9828,-347.3782 161.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"164.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-347.3782 188.9828,-368.3782 221.9828,-368.3782 221.9828,-347.3782 188.9828,-347.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-354.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.85</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"161.9828,-324.3782 161.9828,-345.3782 186.9828,-345.3782 186.9828,-324.3782 161.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"166.4828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"188.9828,-324.3782 188.9828,-345.3782 221.9828,-345.3782 221.9828,-324.3782 188.9828,-324.3782\"/>\n<text text-anchor=\"start\" x=\"191.9828\" y=\"-331.1782\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.15</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"158.9828,-321.8782 158.9828,-394.8782 224.9828,-394.8782 224.9828,-321.8782 158.9828,-321.8782\"/>\n</g>\n<!-- smoke&#45;&gt;lung -->\n<g id=\"edge3\" class=\"edge\">\n<title>smoke&#45;&gt;lung</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M219.2153,-453.7247C216.3817,-443.8037 213.4048,-433.381 210.5018,-423.2171\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"213.8601,-422.2307 207.7483,-413.5764 207.1293,-424.1532 213.8601,-422.2307\"/>\n</g>\n<!-- bronc -->\n<g id=\"node5\" class=\"node\">\n<title>bronc</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-207.8269\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-219.8269 247.9828,-240.8269 307.9828,-240.8269 307.9828,-219.8269 247.9828,-219.8269\"/>\n<text text-anchor=\"start\" x=\"257.4828\" y=\"-226.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> bronc </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-196.8269 247.9828,-217.8269 272.9828,-217.8269 272.9828,-196.8269 247.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-196.8269 274.9828,-217.8269 307.9828,-217.8269 307.9828,-196.8269 274.9828,-196.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-203.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.13</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-173.8269 247.9828,-194.8269 272.9828,-194.8269 272.9828,-173.8269 247.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-173.8269 274.9828,-194.8269 307.9828,-194.8269 307.9828,-173.8269 274.9828,-173.8269\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-180.6269\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.87</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-171.3269 244.9828,-244.3269 310.9828,-244.3269 310.9828,-171.3269 244.9828,-171.3269\"/>\n</g>\n<!-- smoke&#45;&gt;bronc -->\n<g id=\"edge4\" class=\"edge\">\n<title>smoke&#45;&gt;bronc</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M250.8002,-453.512C253.8963,-441.1332 256.8425,-428.0108 258.9828,-415.6539 267.0488,-369.0849 271.8279,-316.0137 274.5755,-275.158\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"278.0767,-275.2511 275.2311,-265.0456 271.0914,-274.7982 278.0767,-275.2511\"/>\n</g>\n<!-- lung&#45;&gt;either -->\n<g id=\"edge5\" class=\"edge\">\n<title>lung&#45;&gt;either</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M174.5179,-303.5999C171.2547,-293.3651 167.8171,-282.5831 164.4725,-272.0926\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"167.807,-271.0288 161.4346,-262.5645 161.1377,-273.1552 167.807,-271.0288\"/>\n</g>\n<!-- dysp -->\n<g id=\"node8\" class=\"node\">\n<title>dysp</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"277.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-69.2756 247.9828,-90.2756 307.9828,-90.2756 307.9828,-69.2756 247.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"259.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> dysp </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-46.2756 247.9828,-67.2756 272.9828,-67.2756 272.9828,-46.2756 247.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"250.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-46.2756 274.9828,-67.2756 307.9828,-67.2756 307.9828,-46.2756 274.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"247.9828,-23.2756 247.9828,-44.2756 272.9828,-44.2756 272.9828,-23.2756 247.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"252.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"274.9828,-23.2756 274.9828,-44.2756 307.9828,-44.2756 307.9828,-23.2756 274.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"277.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">1.00</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"244.9828,-20.7756 244.9828,-93.7756 310.9828,-93.7756 310.9828,-20.7756 244.9828,-20.7756\"/>\n</g>\n<!-- bronc&#45;&gt;dysp -->\n<g id=\"edge6\" class=\"edge\">\n<title>bronc&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M277.9828,-150.4805C277.9828,-142.2097 277.9828,-133.6324 277.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"281.4829,-124.9614 277.9828,-114.9614 274.4829,-124.9614 281.4829,-124.9614\"/>\n</g>\n<!-- xray -->\n<g id=\"node7\" class=\"node\">\n<title>xray</title>\n<ellipse fill=\"none\" stroke=\"#000000\" cx=\"143.9828\" cy=\"-57.2756\" rx=\"57.9655\" ry=\"57.0522\"/>\n<polygon fill=\"#d23939\" stroke=\"transparent\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-69.2756 113.9828,-90.2756 173.9828,-90.2756 173.9828,-69.2756 113.9828,-69.2756\"/>\n<text text-anchor=\"start\" x=\"126.9828\" y=\"-76.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\"> xray </text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-46.2756 113.9828,-67.2756 138.9828,-67.2756 138.9828,-46.2756 113.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"116.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">yes</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-46.2756 140.9828,-67.2756 173.9828,-67.2756 173.9828,-46.2756 140.9828,-46.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-53.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.75</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"113.9828,-23.2756 113.9828,-44.2756 138.9828,-44.2756 138.9828,-23.2756 113.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"118.4828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">no</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"140.9828,-23.2756 140.9828,-44.2756 173.9828,-44.2756 173.9828,-23.2756 140.9828,-23.2756\"/>\n<text text-anchor=\"start\" x=\"143.9828\" y=\"-30.0756\" font-family=\"Times,serif\" font-size=\"14.00\" fill=\"#000000\">0.25</text>\n<polygon fill=\"none\" stroke=\"#000000\" points=\"110.9828,-20.7756 110.9828,-93.7756 176.9828,-93.7756 176.9828,-20.7756 110.9828,-20.7756\"/>\n</g>\n<!-- either&#45;&gt;xray -->\n<g id=\"edge7\" class=\"edge\">\n<title>either&#45;&gt;xray</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M143.9828,-150.4805C143.9828,-142.2097 143.9828,-133.6324 143.9828,-125.1801\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"147.4829,-124.9614 143.9828,-114.9614 140.4829,-124.9614 147.4829,-124.9614\"/>\n</g>\n<!-- either&#45;&gt;dysp -->\n<g id=\"edge8\" class=\"edge\">\n<title>either&#45;&gt;dysp</title>\n<path fill=\"none\" stroke=\"#000000\" d=\"M182.3818,-164.685C198.0813,-147.0463 216.36,-126.5099 232.7048,-108.1462\"/>\n<polygon fill=\"#000000\" stroke=\"#000000\" points=\"235.544,-110.2207 239.5781,-100.4239 230.3151,-105.5667 235.544,-110.2207\"/>\n</g>\n</g>\n</svg>\n"
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 16
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
-      "cell_type": "markdown",
+      "cell_type": "code",
       "metadata": {
-        "id": "fxLt4NZEHEGp"
+        "id": "24L0MlUXCgDw"
       },
       "source": [
-        "# Visualization of posterior marginals"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "1ZgEQUrOHIyK"
-      },
-      "source": [
-        "\n",
-        "<img src=\"https://user-images.githubusercontent.com/4632336/118872284-40b65700-b89d-11eb-8739-bc94fce6808a.png?raw=true\">\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "C62naP3VJFbV"
-      },
-      "source": [
-        "# Explanatory text from the book.\n",
-        "\n",
-        "In this section,\n",
-        "we consider a hypothetical medical\n",
-        "model proposed in \\citep{Lauritzen88}\n",
-        "which is\n",
-        "known in the literature as the ``\\keywordDef{Asia network}''.\n",
-        "(The name comes  from the fact\n",
-        "that was designed to diagnoise various\n",
-        "lung diseases in Western patients returning from a trip to Asia.\n",
-        "Note that this example predates \n",
-        "the \\COVID pandemic by many years, and is a purely fictitious model.)\n",
-        "\n",
-        "\\cref{fig:pgmAsia1} shows the model, as well as the prior\n",
-        "marginal distributions over each node (assumed to be binary).\n",
-        "Now suppose the patient reports that they have \\keywordDef{Dyspnea},\n",
-        "aka shortness of breath.\n",
-        "We can represent this fact\n",
-        "``clamping'' the distribution to be 100\\% probability\n",
-        "that Dyspnea=Present, and 0\\% probability that Dyspnea=Absent.\n",
-        "We then propagate this new  information  through the network\n",
-        "to get the updated marginal distributions shown in\n",
-        "\\cref{fig:pgmAsia2}.\n",
-        "We see that the probability\n",
-        "of lung cancer has gone up from 5\\% to 10\\%,\n",
-        "and probability of bronchitis has gone up  from 45\\% to 83\\%.\n",
-        "\n",
-        "However, it could also be a an undiagnosed case of TB (tuberculosis),\n",
-        "which may have been caused by exposure to an infectious lung disease\n",
-        "that was prevalent in Asia at the time.\n",
-        "So he doctor asks the patient if they have recently been to Asia,\n",
-        "and they say yes.  \\cref{fig:pgmAsia3} shows the new belief state of each node.\n",
-        "We see that the probability of TB has increased from 2\\% to 9\\%.\n",
-        "However, Bronchitis remains the most likely explanation of the symptoms.\n",
-        "\n",
-        "To gain more information the doctor asks\n",
-        "if the patient smokes, and they say yes.\n",
-        "\\cref{fig:pgmAsia3} shows the new belief state of each node.\n",
-        "Now the probability of cancer and bronchitis have both gone up.\n",
-        "In addition, the posterior predicted probability that an X-ray\n",
-        "will show an abnormal result has gone up to 24\\%, so the doctor may decide\n",
-        "it is now worth ordering a test to verify this hypothesis.\n",
-        "\n",
-        "This example illustrates the nature of recursive Bayesian updating,\n",
-        "and how it can be useful for active learning and sequential decision making,\n",
-        "We will see more examples later in the book."
-      ]
+        ""
+      ],
+      "execution_count": null,
+      "outputs": []
     }
   ]
 }


### PR DESCRIPTION
@murphyk and @mjsML please review this. Numpyro allows visualizing by creating plates, but I found the graphviz feature of representing each node as an `HTML` table more appealing. I believe this will help in looking at the student_network model better, which has tables to be visualized at each node. 

Thanks :)

Closes #458 

