### PR TITLE
Updated numpyro code to use new MCMC() interface

### DIFF
--- a/notebooks/logreg_ucb_admissions_numpyro.ipynb
+++ b/notebooks/logreg_ucb_admissions_numpyro.ipynb
@@ -5,8 +5,11 @@
     "colab": {
       "name": "logreg_ucb_admissions_numpyro.ipynb",
       "provenance": [],
-      "toc_visible": true,
-      "authorship_tag": "ABX9TyPcwDTrXC92FjUn9/3Vdw7B",
+      "collapsed_sections": [
+        "aIEJ5zrH288g",
+        "hVaUNn1mBt0F",
+        "aZCWR2nW6lyz"
+      ],
       "include_colab_link": true
     },
     "kernelspec": {
@@ -25,7 +28,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/logreg_ucb_admissions_numpyro.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/always-newbie161/pyprobml/blob/issue_hermes78/notebooks/logreg_ucb_admissions_numpyro.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -54,7 +57,7 @@
         "!pip install -q numpyro@git+https://github.com/pyro-ppl/numpyro\n",
         "!pip install -q arviz\n"
       ],
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -79,7 +82,7 @@
         "import arviz as az\n",
         "az.__version__\n"
       ],
-      "execution_count": 2,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -110,7 +113,7 @@
       "source": [
         "!pip install causalgraphicalmodels"
       ],
-      "execution_count": 3,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -140,7 +143,7 @@
       "source": [
         "#!pip install -U daft"
       ],
-      "execution_count": 4,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -189,7 +192,7 @@
         "\n",
         "from sklearn.preprocessing import StandardScaler"
       ],
-      "execution_count": 5,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -222,7 +225,7 @@
         "n = jax.local_device_count()\n",
         "print(n)"
       ],
-      "execution_count": 6,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -259,7 +262,7 @@
         "d = UCBadmit\n",
         "display(d)\n"
       ],
-      "execution_count": 7,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -425,7 +428,7 @@
       "source": [
         "print(d.to_latex(index=False))"
       ],
-      "execution_count": 8,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -475,7 +478,7 @@
         "\n",
         "print(dat_list)"
       ],
-      "execution_count": 22,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -500,7 +503,7 @@
         "d.applications[dat_list[\"dept_id\"].copy() == 2]\n",
         "               "
       ],
-      "execution_count": 13,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -530,7 +533,7 @@
       "source": [
         "d.applications[dat_list[\"dept_id\"].copy() == 2].sum()"
       ],
-      "execution_count": 14,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -574,7 +577,7 @@
         "display(pg.round(2))\n",
         "print(pg.to_latex())"
       ],
-      "execution_count": 15,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -684,7 +687,7 @@
         "display(pg.round(2))\n",
         "print(pg.to_latex())"
       ],
-      "execution_count": 16,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -798,11 +801,11 @@
         "    numpyro.sample(\"admit\", dist.Binomial(applications, logits=logit_p), obs=admit)\n",
         "\n",
         "\n",
-        "m11_7 = MCMC(NUTS(model), 500, 500, num_chains=4)\n",
+        "m11_7 = MCMC(NUTS(model), num_warmup=500, num_samples=500, num_chains=4)\n",
         "m11_7.run(random.PRNGKey(0), **dat_list)\n",
         "m11_7.print_summary(0.89)"
       ],
-      "execution_count": 17,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -845,7 +848,7 @@
         "diff_p = expit(post[\"a\"][:, 0]) - expit(post[\"a\"][:, 1])\n",
         "print_summary({\"diff_a\": diff_a, \"diff_p\": diff_p}, 0.89, False)"
       ],
-      "execution_count": 18,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -903,7 +906,7 @@
         "      )\n",
         "  plt.gca().set(ylim=(0, 1), xticks=range(1, 13), ylabel=\"admit\", xlabel=\"case\")"
       ],
-      "execution_count": 19,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -921,7 +924,7 @@
         "plt.savefig('admissions_ppc.pdf', dpi=300)\n",
         "plt.show()"
       ],
-      "execution_count": 20,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -967,11 +970,11 @@
         "    numpyro.sample(\"admit\", dist.Binomial(applications, logits=logit_p), obs=admit)\n",
         "\n",
         "\n",
-        "m11_8 = MCMC(NUTS(model), 2000, 2000, num_chains=4)\n",
+        "m11_8 = MCMC(NUTS(model), num_warmup=2000, num_samples=2000, num_chains=4)\n",
         "m11_8.run(random.PRNGKey(0), **dat_list)\n",
         "m11_8.print_summary(0.89)"
       ],
-      "execution_count": 24,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1020,7 +1023,7 @@
         "diff_p = expit(post[\"a\"][:, 0]) - expit(post[\"a\"][:, 1])\n",
         "print_summary({\"diff_a\": diff_a, \"diff_p\": diff_p}, 0.89, False)"
       ],
-      "execution_count": 25,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1054,7 +1057,7 @@
         "plt.savefig('admissions_ppc_per_dept.pdf', dpi=300)\n",
         "plt.show()"
       ],
-      "execution_count": 26,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1112,12 +1115,12 @@
         "p_binom, losses = svi.run(random.PRNGKey(0), 1000)\n",
         "'''\n",
         "\n",
-        "m_binom = MCMC(NUTS(model), 500, 500, num_chains=4)\n",
+        "m_binom = MCMC(NUTS(model), num_warmup=500, num_samples=500, num_chains=4)\n",
         "m_binom.run(random.PRNGKey(0), d.applications.values, d.admit.values)\n",
         "m_binom.print_summary(0.95)\n",
         "\n"
       ],
-      "execution_count": 27,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1157,7 +1160,7 @@
         "logit = jnp.mean(m_binom.get_samples()[\"a\"])\n",
         "print(expit(logit))"
       ],
-      "execution_count": 28,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1186,12 +1189,12 @@
         "    numpyro.sample(\"admit\", dist.Poisson(lambda1), obs=admit)\n",
         "\n",
         "\n",
-        "m_pois = MCMC(NUTS(model), 1000, 1000, num_chains=3)\n",
+        "m_pois = MCMC(NUTS(model), num_warmup=1000, num_samples=1000, num_chains=3)\n",
         "m_pois.run(random.PRNGKey(0), d.reject.values, d.admit.values)\n",
         "m_pois.print_summary(0.95)\n",
         "                     \n"
       ],
-      "execution_count": 29,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1236,7 +1239,7 @@
         "print([lam1, lam2])\n",
         "print(lam1 / (lam1 + lam2))"
       ],
-      "execution_count": 30,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1283,10 +1286,10 @@
         "    numpyro.sample(\"A\", dist.BetaBinomial(pbar * theta, (1 - pbar) * theta, N), obs=A)\n",
         "\n",
         "\n",
-        "m12_1 = MCMC(NUTS(model), 500, 500, num_chains=4)\n",
+        "m12_1 = MCMC(NUTS(model), num_warmup=500, num_samples=500, num_chains=4)\n",
         "m12_1.run(random.PRNGKey(0), **dat)"
       ],
-      "execution_count": 31,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1317,7 +1320,7 @@
         "post[\"da\"] = post[\"a\"][:, 0] - post[\"a\"][:, 1]\n",
         "print_summary(post, 0.89, False)"
       ],
-      "execution_count": 32,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1347,7 +1350,7 @@
       "source": [
         "post"
       ],
-      "execution_count": 33,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -1402,7 +1405,7 @@
         "plt.savefig('admissions_betabinom_female_rate.pdf')\n",
         "plt.show()"
       ],
-      "execution_count": 34,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1456,7 +1459,7 @@
         "plt.savefig('admissions_betabinom_rates.pdf')\n",
         "plt.show()"
       ],
-      "execution_count": 35,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1505,7 +1508,7 @@
         "plt.savefig('admissions_betabinom_post_pred.pdf')\n",
         "plt.show()"
       ],
-      "execution_count": 36,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1579,18 +1582,18 @@
         "    for i in range(len(dept)):\n",
         "        print(row_format.format(dept[i], male[i], probs[i], *quantiles[:, i]), \"\\n\")\n"
       ],
-      "execution_count": 40,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "tGUqrgCgHlPt",
-        "outputId": "8f9e1a80-05e8-4ef3-9b0c-5bf23cf3ebb6",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 961
-        }
+        },
+        "outputId": "8f9e1a80-05e8-4ef3-9b0c-5bf23cf3ebb6"
       },
       "source": [
         "\n",
@@ -1630,7 +1633,7 @@
         "\n",
         "plt.savefig(\"ucbadmit_plot.pdf\")"
       ],
-      "execution_count": 41,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -1725,7 +1728,7 @@
         "display(out)  \n",
         "out.render(filename='admissions_dag', format='pdf')"
       ],
-      "execution_count": 37,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1777,7 +1780,7 @@
         "display(out)  \n",
         "out.render(filename='admissions_dag_hidden', format='pdf')"
       ],
-      "execution_count": 38,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "display_data",
@@ -1873,7 +1876,7 @@
         "post = m6_11.sample_posterior(random.PRNGKey(1), p6_11, (1000,))\n",
         "print_summary(post, 0.89, False)\n",
         "\n",
-        "mcmc_run = MCMC(NUTS(model_linreg), 200, 200, num_chains=4)\n",
+        "mcmc_run = MCMC(NUTS(model_linreg), num_warmup=200, num_samples=200, num_chains=4)\n",
         "mcmc_run.run(random.PRNGKey(0), **data)\n",
         "mcmc_run.print_summary(0.89)"
       ],
@@ -2043,7 +2046,7 @@
         "\n",
         "warmup  = 1000\n",
         "samples = 500\n",
-        "mcmc_run = MCMC(NUTS(model_logreg), warmup, samples, num_chains=4)\n",
+        "mcmc_run = MCMC(NUTS(model_logreg), num_warmup=warmup, num_samples=samples, num_chains=4)\n",
         "mcmc_run.run(random.PRNGKey(0), **data)\n",
         "mcmc_run.print_summary(0.89)"
       ],


### PR DESCRIPTION
Closes probml/hermes#78

Only, `notebooks/logreg_ucb_admissions_numpyro.ipynb` dont have explicit args, all other numpyro scripts and notebooks either dont use MCMC or are following the updated API

@murphyk

- [x] numpyro scripts
- [x] numpyro notebooks