### PR TITLE
Parallel Kalman Filtering and refactor

### DIFF
--- a/scripts/linear_dynamical_systems_lib.py
+++ b/scripts/linear_dynamical_systems_lib.py
@@ -1,6 +1,7 @@
 # Jax implementation of a Linear Dynamical System
 # Author:  Gerardo Duran-Martin (@gerdm)
 
+import jax
 import jax.numpy as jnp
 from jax import random
 from jax.ops import index_update
@@ -24,68 +25,84 @@ class LinearDynamicalSystem:
         Transition covariance matrix
     R: array(observation_size, observation_size)
         Observation covariance
-    μ0: array(state_size)
+    mu0: array(state_size)
         Mean of initial configuration
-    Σ0: array(state_size, state_size) or 0
+    Sigma0: array(state_size, state_size) or 0
         Covariance of initial configuration. If value is set
         to zero, the initial state will be completely determined
-        by μ0
+        by mu0
     timesteps: int
         Total number of steps to sample
     """
-    def __init__(self, A, C, Q, R, μ0, Σ0=None, timesteps=15):
+    def __init__(self, A, C, Q, R, mu0, Sigma0=None, timesteps=15):
         self.A = A
         self.C = C
         self.Q = Q
         self.R = R
-        self.μ0 = μ0
-        self.Σ0 = Σ0
+        self.mu0 = mu0
+        self.Sigma0 = Sigma0
         self.timesteps = timesteps
         self.state_size, _ = A.shape
         self.observation_size, _ = C.shape
 
-    def sample(self, key, sample_intial_state=False):
+    def sample(self, key, n_samples=1, sample_intial_state=False):
         """
-        # To-do: implement switching systems
-        Simulate a run of (switching) stochastic linear dynamical systems
+        Simulate a run of n_sample independent stochastic
+        linear dynamical systems
 
         Parameters
         ----------
         key: jax.random.PRNGKey
             Seed of initial random states
+        n_samples: int
+            Number of independent linear systems with shared dynamics (optional)
+        sample_initial_state: bool
+            Whether to sample from an initial state or sepecified
 
         Returns
         -------
-        * array(timesteps, state_size):
+        * array(n_samples, timesteps, state_size):
             Simulation of Latent states
-        * array(timesteps, observation_size):
+        * array(n_samples, timesteps, observation_size):
             Simulation of observed states
         """
-        key_z1, key_eps, key_delta = random.split(key, 3)
+        key_z1, key_system_noise, key_obs_noise = random.split(key, 3)
         if not sample_intial_state:
-            z1 =self.μ0
+            state_t =self.mu0 * jnp.ones((n_samples, self.state_size))
         else:
-            z1 = random.multivariate_normal(key_z1, self.μ0, self.Σ0)
+            state_t = random.multivariate_normal(key_z1, self.mu0, self.Sigma0, (n_samples,))
 
         # Generate all future noise terms
-        eps = random.multivariate_normal(key_eps, jnp.zeros(self.state_size), self.Q, (self.timesteps, ))
-        delta = random.multivariate_normal(key_delta, jnp.zeros(self.observation_size), self.R, (self.timesteps, ))
+        zeros_state = jnp.zeros(self.state_size)
+        zeros_obs = jnp.zeros(self.observation_size)
+        system_noise = random.multivariate_normal(key_system_noise, zeros_state, self.Q, (n_samples, self.timesteps))
+        obs_noise = random.multivariate_normal(key_obs_noise, zeros_obs, self.R, (n_samples, self.timesteps))
         
-        z_hist = jnp.zeros((self.timesteps, self.state_size))
-        x_hist = jnp.zeros((self.timesteps, self.observation_size))
+        state_hist = jnp.zeros((n_samples, self.timesteps, self.state_size))
+        obs_hist = jnp.zeros((n_samples, self.timesteps, self.observation_size))
 
-        z_hist = index_update(z_hist, 0, z1)
-        x_hist = index_update(x_hist, 0, self.C @ z1 + delta[0])
+        obs_t = jnp.einsum("ij,sj->si", self.C, state_t) + obs_noise[:, 0, :]
+
+        state_hist = index_update(state_hist, jax.ops.index[:, 0, :], state_t)
+        obs_hist = index_update(obs_hist, jax.ops.index[:, 0, :], obs_t)
+
         for t in range(1, self.timesteps):
-            zt = self.A @ z_hist[t-1] + eps[t]
-            xt = self.C @ zt + delta[t]
+            system_noise_t = system_noise[:, t, :]
+            obs_noise_t = obs_noise[:, t, :]
 
-            z_hist = index_update(z_hist, t, zt)
-            x_hist = index_update(x_hist, t, xt)
-        
-        return z_hist, x_hist
+            state_new = jnp.einsum("ij,sj->si", self.A, state_t) + system_noise_t
+            obs_t = jnp.einsum("ij,sj->si", self.C, state_new) + obs_noise_t
+            state_t = state_new
 
-    def kalman_filter(self, x_hist):
+            state_hist = index_update(state_hist, jax.ops.index[:, t, :], state_t)
+            obs_hist = index_update(obs_hist, jax.ops.index[:, t, :], obs_t)
+
+        if n_samples == 1:
+            state_hist = state_hist[0, ...]
+            obs_hist = obs_hist[0, ...]
+        return state_hist, obs_hist
+
+    def __kalman_filter(self, x_hist):
         """
         Compute the online version of the Kalman-Filter, i.e,
         the one-step-ahead prediction for the hidden state or the
@@ -94,70 +111,56 @@ class LinearDynamicalSystem:
         Parameters
         ----------
         x_hist: array(timesteps, observation_size)
-        A: array(state_size, state_size)
-            Transition matrix
-        C: array(observation_size, state_size)
-            Observation matrix
-        Q: array(state_size, state_size)
-            Transition covariance matrix
-        R: array(observation_size, observation_size)
-            Observation covariance
-        μ0: array(state_size)
-            Mean of initial configuration
-        Σ0: array(state_size, state_size) or 0
-            Covariance of initial configuration. If value is set
-            to zero, the initial state will be completely determined
-            by μ0
             
         Returns
         -------
         * array(timesteps, state_size):
-            Filtered means μt
+            Filtered means mut
         * array(timesteps, state_size, state_size)
-            Filtered covariances Σt
+            Filtered covariances Sigmat
         * array(timesteps, state_size)
-            Filtered conditional means μt|t-1
+            Filtered conditional means mut|t-1
         * array(timesteps, state_size, state_size)
-            Filtered conditional covariances Σt|t-1
+            Filtered conditional covariances Sigmat|t-1
         """
         I = jnp.eye(self.state_size)
-        μ_hist = jnp.zeros((self.timesteps, self.state_size))
-        Σ_hist = jnp.zeros((self.timesteps, self.state_size, self.state_size))
-        Σ_cond_hist = jnp.zeros((self.timesteps, self.state_size, self.state_size))
-        μ_cond_hist = jnp.zeros((self.timesteps, self.state_size))
+        mu_hist = jnp.zeros((self.timesteps, self.state_size))
+        Sigma_hist = jnp.zeros((self.timesteps, self.state_size, self.state_size))
+        Sigma_cond_hist = jnp.zeros((self.timesteps, self.state_size, self.state_size))
+        mu_cond_hist = jnp.zeros((self.timesteps, self.state_size))
         
         # Initial configuration
-        K1 = self.Σ0 @ self.C.T @ inv(self.C @ self.Σ0 @ self.C.T + self.R)
-        μ1 = self.μ0 + K1 @ (x_hist[0] - self.C @ self.μ0)
-        Σ1 = (I - K1 @ self.C) @ self.Σ0
+        K1 = self.Sigma0 @ self.C.T @ inv(self.C @ self.Sigma0 @ self.C.T + self.R)
+        mu1 = self.mu0 + K1 @ (x_hist[0] - self.C @ self.mu0)
+        Sigma1 = (I - K1 @ self.C) @ self.Sigma0
 
-        μ_hist = index_update(μ_hist, 0, μ1)
-        Σ_hist = index_update(Σ_hist, 0, Σ1)
-        μ_cond_hist = index_update(μ_cond_hist, 0, self.μ0)
-        Σ_cond_hist = index_update(Σ_hist, 0, self.Σ0)
+        mu_hist = index_update(mu_hist, 0, mu1)
+        Sigma_hist = index_update(Sigma_hist, 0, Sigma1)
+        mu_cond_hist = index_update(mu_cond_hist, 0, self.mu0)
+        Sigma_cond_hist = index_update(Sigma_hist, 0, self.Sigma0)
         
-        Σn = Σ1
+        Sigman = Sigma1
         for n in range(1, self.timesteps):
-            # Σn|{n-1}
-            Σn_cond = self.A @ Σn @ self.A.T + self.Q
-            St = self.C @ Σn_cond @ self.C.T + self.R
-            Kn = Σn_cond @ self.C.T @ inv(St)
+            # Sigman|{n-1}
+            Sigman_cond = self.A @ Sigman @ self.A.T + self.Q
+            St = self.C @ Sigman_cond @ self.C.T + self.R
+            Kn = Sigman_cond @ self.C.T @ inv(St)
 
-            # μn|{n-1} and xn|{n-1}
-            μ_update = self.A @ μ_hist[n-1]
-            x_update = self.C @ μ_update
+            # mun|{n-1} and xn|{n-1}
+            mu_update = self.A @ mu_hist[n-1]
+            x_update = self.C @ mu_update
 
-            μn = μ_update + Kn @ (x_hist[n] - x_update)
-            Σn = (I - Kn @ self.C) @ Σn_cond
+            mun = mu_update + Kn @ (x_hist[n] - x_update)
+            Sigman = (I - Kn @ self.C) @ Sigman_cond
 
-            μ_hist = index_update(μ_hist, n, μn)
-            Σ_hist = index_update(Σ_hist, n, Σn)
-            μ_cond_hist = index_update(μ_cond_hist, n, μ_update)
-            Σ_cond_hist = index_update(Σ_cond_hist, n, Σn_cond)
+            mu_hist = index_update(mu_hist, n, mun)
+            Sigma_hist = index_update(Sigma_hist, n, Sigman)
+            mu_cond_hist = index_update(mu_cond_hist, n, mu_update)
+            Sigma_cond_hist = index_update(Sigma_cond_hist, n, Sigman_cond)
         
-        return μ_hist, Σ_hist, μ_cond_hist, Σ_cond_hist
+        return mu_hist, Sigma_hist, mu_cond_hist, Sigma_cond_hist
 
-    def kalman_smoother(self, μ_hist, Σ_hist, μ_cond_hist, Σ_cond_hist):
+    def __kalman_smoother(self, mu_hist, Sigma_hist, mu_cond_hist, Sigma_cond_hist):
         """
         Compute the offline version of the Kalman-Filter, i.e,
         the kalman smoother for the hidden state.
@@ -165,41 +168,117 @@ class LinearDynamicalSystem:
         
         Parameters
         ----------
-        μ_hist: array(timesteps, state_size):
-            Filtered means μt
-        Σ_hist: array(timesteps, state_size, state_size)
-            Filtered covariances Σt
-        μ_cond_hist: array(timesteps, state_size)
-            Filtered conditional means μt|t-1
-        Σ_cond_hist: array(timesteps, state_size, state_size)
-            Filtered conditional covariances Σt|t-1
+        mu_hist: array(timesteps, state_size):
+            Filtered means mut
+        Sigma_hist: array(timesteps, state_size, state_size)
+            Filtered covariances Sigmat
+        mu_cond_hist: array(timesteps, state_size)
+            Filtered conditional means mut|t-1
+        Sigma_cond_hist: array(timesteps, state_size, state_size)
+            Filtered conditional covariances Sigmat|t-1
             
         Returns
         -------
         * array(timesteps, state_size):
-            Smoothed means μt
+            Smoothed means mut
         * array(timesteps, state_size, state_size)
-            Smoothed covariances Σt
+            Smoothed covariances Sigmat
         """
-        timesteps, _ = μ_hist.shape
+        timesteps, _ = mu_hist.shape
         state_size, _ = self.A.shape
-        μ_hist_smooth = jnp.zeros((timesteps, state_size))
-        Σ_hist_smooth = jnp.zeros((timesteps, state_size, state_size))
+        mu_hist_smooth = jnp.zeros((timesteps, state_size))
+        Sigma_hist_smooth = jnp.zeros((timesteps, state_size, state_size))
 
-        μt_giv_T = μ_hist[-1, :]
-        Σt_giv_T = Σ_hist[-1, :]
+        mut_giv_T = mu_hist[-1, :]
+        Sigmat_giv_T = Sigma_hist[-1, :]
 
         # Update last step
-        μ_hist_smooth = index_update(μ_hist_smooth, -1,  μt_giv_T)
-        Σ_hist_smooth = index_update(Σ_hist_smooth, -1,  Σt_giv_T)
+        mu_hist_smooth = index_update(mu_hist_smooth, -1,  mut_giv_T)
+        Sigma_hist_smooth = index_update(Sigma_hist_smooth, -1,  Sigmat_giv_T)
 
-        elements = zip(μ_hist[-2::-1], Σ_hist[-2::-1, ...], μ_cond_hist[::-1, ...], Σ_cond_hist[::-1, ...])
-        for t, (μtt, Σtt, μt_cond_next, Σt_cond_next) in enumerate(elements, 1):
-            Jt  = Σtt @ self.A.T @ inv(Σt_cond_next)
-            μt_giv_T = μtt + Jt @ (μt_giv_T - μt_cond_next)
-            Σt_giv_T = Σtt + Jt @ (Σt_giv_T - Σt_cond_next) @ Jt.T
+        elements = zip(mu_hist[-2::-1], Sigma_hist[-2::-1, ...], mu_cond_hist[::-1, ...], Sigma_cond_hist[::-1, ...])
+        for t, (mutt, Sigmatt, mut_cond_next, Sigmat_cond_next) in enumerate(elements, 1):
+            Jt  = Sigmatt @ self.A.T @ inv(Sigmat_cond_next)
+            mut_giv_T = mutt + Jt @ (mut_giv_T - mut_cond_next)
+            Sigmat_giv_T = Sigmatt + Jt @ (Sigmat_giv_T - Sigmat_cond_next) @ Jt.T
             
-            μ_hist_smooth = index_update(μ_hist_smooth, -(t+1),  μt_giv_T)
-            Σ_hist_smooth = index_update(Σ_hist_smooth, -(t+1), Σt_giv_T)
+            mu_hist_smooth = index_update(mu_hist_smooth, -(t+1),  mut_giv_T)
+            Sigma_hist_smooth = index_update(Sigma_hist_smooth, -(t+1), Sigmat_giv_T)
         
-        return μ_hist_smooth, Σ_hist_smooth
+        return mu_hist_smooth, Sigma_hist_smooth
+
+    def kalman_filter(self, x_hist):
+        """
+        Compute the online version of the Kalman-Filter, i.e,
+        the one-step-ahead prediction for the hidden state or the
+        time update step.
+
+        Note that x_hist can optionally be of dimensionality two,
+        This corresponds to different samples of the same underlying
+        Linear Dynamical System
+        
+        Parameters
+        ----------
+        x_hist: array(n_samples?, timesteps, observation_size)
+            
+        Returns
+        -------
+        * array(n_samples?, timesteps, state_size):
+            Filtered means mut
+        * array(n_samples?, timesteps, state_size, state_size)
+            Filtered covariances Sigmat
+        * array(n_samples?, timesteps, state_size)
+            Filtered conditional means mut|t-1
+        * array(n_samples?, timesteps, state_size, state_size)
+            Filtered conditional covariances Sigmat|t-1
+        """
+        has_one_sim = False
+        if x_hist.ndim == 2:
+            x_hist = x_hist[None, ...]
+            has_one_sim = True
+        kalman_map = jax.vmap(self.__kalman_filter, 0)
+        mu_hist, Sigma_hist, mu_cond_hist, Sigma_cond_hist = kalman_map(x_hist)
+        if has_one_sim:
+            mu_hist, Sigma_hist, mu_cond_hist, Sigma_cond_hist = mu_hist[0, ...], Sigma_hist[0, ...], mu_cond_hist[0, ...], Sigma_cond_hist[0, ...]
+        return mu_hist, Sigma_hist, mu_cond_hist, Sigma_cond_hist 
+
+
+    def kalman_smoother(self, mu_hist, Sigma_hist, mu_cond_hist, Sigma_cond_hist):
+        """
+        Compute the offline version of the Kalman-Filter, i.e,
+        the kalman smoother for the state space.
+        Note that we require to independently run the kalman_filter function first.
+
+        Note that the mean terms can optionally be of dimensionality two.
+        Similarly, the covariance terms can optinally be of dimensionally three.
+        This corresponds to different samples of the same underlying
+        Linear Dynamical System
+
+        
+        Parameters
+        ----------
+        mu_hist: array(n_samples?, timesteps, state_size):
+            Filtered means mut
+        Sigma_hist: array(n_samples?, timesteps, state_size, state_size)
+            Filtered covariances Sigmat
+        mu_cond_hist: array(n_samples?, timesteps, state_size)
+            Filtered conditional means mut|t-1
+        Sigma_cond_hist: array(n_samples?, timesteps, state_size, state_size)
+            Filtered conditional covariances Sigmat|t-1
+            
+        Returns
+        -------
+        * array(n_samples?, timesteps, state_size):
+            Smoothed means mut
+        * array(timesteps?, state_size, state_size)
+            Smoothed covariances Sigmat
+        """
+        has_one_sim = False
+        if mu_hist.ndim == 2:
+            mu_hist, Sigma_hist, mu_cond_hist, Sigma_cond_hist = mu_hist[None, ...], Sigma_hist[None, ...], mu_cond_hist[None, ...], Sigma_cond_hist[None, ...]
+            has_one_sim = True
+        smoother_map = jax.vmap(self.__kalman_smoother, 0)
+        mu_hist_smooth, Sigma_hist_smooth = smoother_map(mu_hist, Sigma_hist, mu_cond_hist, Sigma_cond_hist)
+        if has_one_sim:
+            mu_hist_smooth, Sigma_hist_smooth = mu_hist_smooth[0, ...], Sigma_hist_smooth[0, ...]
+        return mu_hist_smooth, Sigma_hist_smooth

--- a/scripts/parallel_kalman_filter_demo.py
+++ b/scripts/parallel_kalman_filter_demo.py
@@ -1,0 +1,120 @@
+# Parallel Kalman Filter demo: this script simulates
+# 4 missiles as described in the section "state-space models".
+# Each of the missiles is then filtered and smoothed in parallel
+# Author: Gerardo Duran-Martin (@gerdm)
+
+import jax.numpy as jnp
+import linear_dynamical_systems_lib as lds
+import matplotlib.pyplot as plt
+import pyprobml_utils as pml
+from jax import random
+
+plt.rcParams["axes.spines.right"] = False
+plt.rcParams["axes.spines.top"] = False
+
+def sample_filter_smooth(key, lds_model, n_samples, noisy_init):
+    """
+    Sample from a linear dynamical system, apply the kalman filter
+    (forward pass), and performs smoothing.
+
+    Parameters
+    ----------
+    lds: LinearDynamicalSystem
+        Instance of a linear dynamical system with known parameters
+
+    Returns
+    -------
+    Dictionary with the following key, values
+    * (z_hist) array(n_samples, timesteps, state_size):
+        Simulation of Latent states
+    * (x_hist) array(n_samples, timesteps, observation_size):
+        Simulation of observed states
+    * (mu_hist) array(n_samples, timesteps, state_size):
+        Filtered means mut
+    * (Sigma_hist) array(n_samples, timesteps, state_size, state_size)
+        Filtered covariances Sigmat
+    * (mu_cond_hist) array(n_samples, timesteps, state_size)
+        Filtered conditional means mut|t-1
+    * (Sigma_cond_hist) array(n_samples, timesteps, state_size, state_size)
+        Filtered conditional covariances Sigmat|t-1
+    * (mu_hist_smooth) array(n_samples, timesteps, state_size):
+        Smoothed means mut
+    * (Sigma_hist_smooth) array(n_samples, timesteps, state_size, state_size)
+        Smoothed covariances Sigmat
+    """
+    z_hist, x_hist = lds_model.sample(key, n_samples, noisy_init)
+    mu_hist, Sigma_hist, mu_cond_hist, Sigma_cond_hist = lds_model.kalman_filter(x_hist)
+    mu_hist_smooth, Sigma_hist_smooth = lds_model.kalman_smoother(mu_hist, Sigma_hist, mu_cond_hist, Sigma_cond_hist)
+
+    return {
+        "z_hist": z_hist,
+        "x_hist": x_hist,
+        "mu_hist": mu_hist,
+        "Sigma_hist": Sigma_hist,
+        "mu_cond_hist": mu_cond_hist,
+        "Sigma_cond_hist": Sigma_cond_hist,
+        "mu_hist_smooth": mu_hist_smooth,
+        "Sigma_hist_smooth": Sigma_hist_smooth
+    }
+
+def plot_collection(obs, ax, means=None, covs=None, **kwargs):
+    n_samples, n_steps, _ = obs.shape
+    for nsim in range(n_samples):
+        X = obs[nsim]
+        if means is not None:
+            mean = means[nsim]
+            ax.scatter(*mean[0, :2], marker="o", s=20, c="black", zorder=2)
+            ax.plot(*mean[:, :2].T, marker="o", markersize=2, **kwargs, zorder=1)
+            if covs is not None:
+                cov = covs[nsim]
+                for t in range(1, n_steps, 3):
+                    pml.plot_ellipse(cov[t][:2, :2], mean[t, :2], ax,
+                    plot_center=False, alpha=0.7)
+        ax.scatter(*X.T, marker="+", s=60)
+
+if __name__ == "__main__":
+    Δ = 1.0
+    A = jnp.array([
+        [1, 0, Δ, 0],
+        [0, 1, 0, Δ],
+        [0, 0, 1, 0],
+        [0, 0, 0, 1]
+    ])
+
+    C = jnp.array([
+        [1, 0, 0, 0],
+        [0, 1, 0, 0]
+    ])
+
+    state_size, _ = A.shape
+    observation_size, _ = C.shape
+
+    Q = jnp.eye(state_size) * 0.01
+    R = jnp.eye(observation_size) * 1.2
+    # Prior parameter distribution
+    mu0 = jnp.array([8, 10, 1, 0])
+    Sigma0 = jnp.eye(state_size) * 0.1
+
+    n_samples = 4
+    n_steps = 15
+
+    key = random.PRNGKey(3141)
+    lds_instance = lds.LinearDynamicalSystem(A, C, Q, R, mu0, Sigma0, n_steps)
+    result = sample_filter_smooth(key, lds_instance, n_samples, True)
+
+    fig, ax = plt.subplots()
+    plot_collection(result["x_hist"], ax, result["z_hist"], linestyle="--")
+    ax.set_title("State space")
+    pml.savefig("missiles_latent.pdf")
+
+    fig, ax = plt.subplots()
+    plot_collection(result["x_hist"], ax, result["mu_hist"], result["Sigma_hist"])
+    ax.set_title("Filtered")
+    pml.savefig("missiles_filtered.pdf")
+
+    fig, ax = plt.subplots()
+    plot_collection(result["x_hist"], ax, result["mu_hist_smooth"], result["Sigma_hist_smooth"])
+    ax.set_title("Smoothed")
+    pml.savefig("missiles_smoothed.pdf")
+
+    plt.show()


### PR DESCRIPTION
1. Generalises code to work with the parallel and the single case. It won't break either code
2. Removes `ParallelLinearDynamicalSystem` class
3. `parallel_kalman_filter_demo.py` now considers `LinearDynamicalSystem` to execute the code
4. Simulation of LDS considers einsums (raison d'etre above)
5. Figure output of `parallel_kalman_filter_demo.py` is the following

<img width="1920" alt="Screenshot 2021-06-07 at 17 38 20" src="https://user-images.githubusercontent.com/4108759/121058611-6e196500-c7b8-11eb-8d40-355de74d28d7.png">


Furthermore, replace greek symbols for English ASCII in ` scripts/linear_dynamical_systems_lib.py` for usability

For example. Change:
```python
# Initial configuration
K1 = self.Σ0 @ self.C.T @ inv(self.C @ self.Σ0 @ self.C.T + self.R)
μ1 = self.μ0 + K1 @ (x_hist[0] - self.C @ self.μ0)
Σ1 = (I - K1 @ self.C) @ self.Σ0

μ_hist = index_update(μ_hist, 0, μ1)
Σ_hist = index_update(Σ_hist, 0, Σ1)
μ_cond_hist = index_update(μ_cond_hist, 0, self.μ0)
Σ_cond_hist = index_update(Σ_hist, 0, self.Σ0)
```
in favour of
```python
# Initial configuration
K1 = self.Sigma0 @ self.C.T @ inv(self.C @ self.Sigma0 @ self.C.T + self.R)
mu1 = self.mu0 + K1 @ (x_hist[0] - self.C @ self.mu0)
Sigma1 = (I - K1 @ self.C) @ self.Sigma0

mu_hist = index_update(mu_hist, 0, mu1)
Sigma_hist = index_update(Sigma_hist, 0, Sigma1)
mu_cond_hist = index_update(mu_cond_hist, 0, self.mu0)
Sigma_cond_hist = index_update(Sigma_hist, 0, self.Sigma0)
```