### PR TITLE
Refactor `nlds_lib.py`

### DIFF
--- a/scripts/ekf_vs_ukf_demo.py
+++ b/scripts/ekf_vs_ukf_demo.py
@@ -62,14 +62,14 @@ def plot_inference(sample_obs, mean_hist, Sigma_hist):
 plot_data(sample_state, sample_obs)
 pml.savefig("nlds2d_data.pdf")
 
-ekf = ds.ExtendedKalmanFilter(lambda x: fz(x, dt), fx, Qt, Rt)
+ekf = ds.ExtendedKalmanFilter.from_base(model)
 mean_hist, Sigma_hist = ekf.filter(x0, sample_obs)
 plot_inference(sample_obs, mean_hist, Sigma_hist)
 plt.title('EKF')
 pml.savefig("nlds2d_ekf.pdf")
 
 alpha, beta, kappa = 1, 0, 2
-ukf = ds.UnscentedKalmanFilter(lambda x: fz(x, dt), fx, Qt, Rt, alpha, beta, kappa)
+ukf = ds.UnscentedKalmanFilter.from_base(model, alpha, beta, kappa)
 mean_hist, Sigma_hist = ukf.filter(x0, sample_obs)
 plot_inference(sample_obs, mean_hist, Sigma_hist)
 plt.title('UKF')

--- a/scripts/ekf_vs_ukf_demo.py
+++ b/scripts/ekf_vs_ukf_demo.py
@@ -10,30 +10,9 @@ from jax import random
 plt.rcParams["axes.spines.right"] = False
 plt.rcParams["axes.spines.top"] = False
 
+
 def check_symmetric(a, rtol=1.1):
     return jnp.allclose(a, a.T, rtol=rtol)
-
-
-def fz(x, dt):
-    return x + dt * jnp.array([jnp.sin(x[1]), jnp.cos(x[0])])
-def fx(x): return x
-
-
-dt = 0.4
-nsteps = 100
-
-# Initial state vector
-x0 = jnp.array([1.5, 0.0])
-
-# State noise
-Qt = jnp.eye(2) * 0.001
-# Observed noise
-Rt = jnp.eye(2) * 0.05
-alpha, beta, kappa = 1, 0, 2
-
-key = random.PRNGKey(314)
-model = ds.NLDS(lambda x: fz(x, dt), fx, Qt, Rt)
-sample_state, sample_obs = model.sample(key, x0, nsteps)
 
 
 def plot_data(sample_state, sample_obs):
@@ -58,21 +37,38 @@ def plot_inference(sample_obs, mean_hist, Sigma_hist):
         pml.plot_ellipse(Vt, mut, ax, plot_center=False, alpha=0.9, zorder=3)
     plt.axis("equal")
 
+if __name__ == "__main__":
+    def fz(x, dt): return x + dt * jnp.array([jnp.sin(x[1]), jnp.cos(x[0])])
+    def fx(x): return x
 
-plot_data(sample_state, sample_obs)
-pml.savefig("nlds2d_data.pdf")
+    dt = 0.4
+    nsteps = 100
+    # Initial state vector
+    x0 = jnp.array([1.5, 0.0])
+    # State noise
+    Qt = jnp.eye(2) * 0.001
+    # Observed noise
+    Rt = jnp.eye(2) * 0.05
+    alpha, beta, kappa = 1, 0, 2
 
-ekf = ds.ExtendedKalmanFilter.from_base(model)
-mean_hist, Sigma_hist = ekf.filter(x0, sample_obs)
-plot_inference(sample_obs, mean_hist, Sigma_hist)
-plt.title('EKF')
-pml.savefig("nlds2d_ekf.pdf")
+    key = random.PRNGKey(314)
+    model = ds.NLDS(lambda x: fz(x, dt), fx, Qt, Rt)
+    sample_state, sample_obs = model.sample(key, x0, nsteps)
+    ekf = ds.ExtendedKalmanFilter.from_base(model)
+    ukf = ds.UnscentedKalmanFilter.from_base(model, alpha, beta, kappa)
 
-alpha, beta, kappa = 1, 0, 2
-ukf = ds.UnscentedKalmanFilter.from_base(model, alpha, beta, kappa)
-mean_hist, Sigma_hist = ukf.filter(x0, sample_obs)
-plot_inference(sample_obs, mean_hist, Sigma_hist)
-plt.title('UKF')
-pml.savefig("nlds2d_ukf.pdf")
+    ekf_mean_hist, ekf_Sigma_hist = ekf.filter(x0, sample_obs)
+    ukf_mean_hist, ukf_Sigma_hist = ukf.filter(x0, sample_obs)
 
-plt.show()
+    plot_data(sample_state, sample_obs)
+    pml.savefig("nlds2d_data.pdf")
+
+    plot_inference(sample_obs, ekf_mean_hist, ekf_Sigma_hist)
+    plt.title("EKF")
+    pml.savefig("nlds2d_ekf.pdf")
+
+    plot_inference(sample_obs, ukf_mean_hist, ukf_Sigma_hist)
+    plt.title("UKF")
+    pml.savefig("nlds2d_ukf.pdf")
+
+    plt.show()

--- a/scripts/ekf_vs_ukf_demo.py
+++ b/scripts/ekf_vs_ukf_demo.py
@@ -32,7 +32,7 @@ Rt = jnp.eye(2) * 0.05
 alpha, beta, kappa = 1, 0, 2
 
 key = random.PRNGKey(314)
-model = ds.ExtendedKalmanFilter(lambda x: fz(x, dt), fx, Qt, Rt)
+model = ds.NLDS(lambda x: fz(x, dt), fx, Qt, Rt)
 sample_state, sample_obs = model.sample(key, x0, nsteps)
 
 

--- a/scripts/nlds_lib.py
+++ b/scripts/nlds_lib.py
@@ -71,6 +71,10 @@ class ExtendedKalmanFilter(NLDS):
         super().__init__(fz, fx, Q, R)
         self.Dfz = jax.jacfwd(fz)
         self.Dfx = jax.jacfwd(fx)
+    
+    @classmethod
+    def from_base(cls, model):
+        return cls(model.fz, model.fx, model.Q, model.R)
 
     def filter(self, init_state, sample_obs):
         """
@@ -285,6 +289,10 @@ class UnscentedKalmanFilter(NLDS):
         self.kappa = kappa
         self.lmbda = alpha ** 2 * (self.d + kappa) - self.d
         self.gamma = jnp.sqrt(self.d + self.lmbda)
+
+    @classmethod
+    def from_base(cls, model, alpha, beta, kappa):
+        return cls(model.fz, model.fx, model.Q, model.R, alpha, beta, kappa)
     
     @staticmethod
     def sqrtm(M):

--- a/scripts/nlds_lib.py
+++ b/scripts/nlds_lib.py
@@ -12,14 +12,14 @@ class NLDS:
     """
     Base class for the Nonliear dynamical systems' module
     """
-    def __init__(self, fz, fx, Qt, Rt):
+    def __init__(self, fz, fx, Q, R):
         self.fz = fz
         self.fx = fx
-        self.Qt = Qt
-        self.Rt = Rt
-        self.state_size, _ = Qt.shape
-        self.obs_size, _ = Rt.shape
-    
+        self.Q = Q
+        self.R = R
+        self.state_size, _ = Q.shape
+        self.obs_size, _ = R.shape
+
     def sample(self, key, x0, nsteps):
         """
         Sample discrete elements of a nonlinear system

--- a/scripts/nlds_lib.py
+++ b/scripts/nlds_lib.py
@@ -8,6 +8,59 @@ from jax.ops import index_update
 from math import ceil
 
 
+class NLDS:
+    """
+    Base class for the Nonliear dynamical systems' module
+    """
+    def __init__(self, fz, fx, Qt, Rt):
+        self.fz = fz
+        self.fx = fx
+        self.Qt = Qt
+        self.Rt = Rt
+        self.state_size, _ = Qt.shape
+        self.obs_size, _ = Rt.shape
+    
+    def sample(self, key, x0, nsteps):
+        """
+        Sample discrete elements of a nonlinear system
+
+        Parameters
+        ----------
+        key: jax.random.PRNGKey
+        x0: array(state_size)
+            Initial state of simulation
+        nsteps: int
+            Total number of steps to sample from the system
+
+        Returns
+        -------
+        * array(nsamples, state_size)
+            State-space values
+        * array(nsamples, obs_size)
+            Observed-space values
+        """
+        key, key_system_noise, key_obs_noise = random.split(key, 3)
+
+        state_hist = jnp.zeros((nsteps, self.state_size))
+        obs_hist = jnp.zeros((nsteps, self.obs_size))
+
+        state_t = x0.copy()
+        obs_t = self.fx(state_t)
+
+        state_noise = random.multivariate_normal(key_system_noise, jnp.zeros((self.state_size,)), self.Q, (nsteps,))
+        obs_noise = random.multivariate_normal(key_obs_noise, jnp.zeros((self.obs_size,)), self.R, (nsteps,))
+        state_hist = index_update(state_hist, 0, state_t)
+        obs_hist = index_update(obs_hist, 0, obs_t)
+
+        for t in range(1, nsteps):
+            state_t = self.fz(state_t) + state_noise[t]
+            obs_t = self.fx(state_t) + obs_noise[t]
+
+            state_hist = index_update(state_hist, t, state_t)
+            obs_hist = index_update(obs_hist, t, obs_t)
+        
+        return state_hist, obs_hist
+
 class ExtendedKalmanFilter:
     """
     Implementation of the Extended Kalman Filter for a nonlinear

--- a/scripts/nlds_lib.py
+++ b/scripts/nlds_lib.py
@@ -273,15 +273,12 @@ class ContinuousExtendedKalmanFilter:
         return mu_hist, V_hist
 
 
-class UnscentedKalmanFilter:
+class UnscentedKalmanFilter(NLDS):
     """
     Implementation of the Unscented Kalman Filter for discrete time systems
     """
     def __init__(self, fz, fx, Q, R, alpha, beta, kappa):
-        self.fz = fz
-        self.fx = fx
-        self.Q = Q
-        self.R = R
+        super().__init__(fz, fx, Q, R)
         self.d, _ = Q.shape
         self.alpha = alpha
         self.beta = beta
@@ -308,47 +305,6 @@ class UnscentedKalmanFilter:
         R = evecs @ jnp.sqrt(jnp.diag(evals)) @ jnp.linalg.inv(evecs)
         return R
     
-    def sample(self, key, x0, nsteps):
-        """
-        Sample discrete elements of a nonlinear system
-
-        Parameters
-        ----------
-        key: jax.random.PRNGKey
-        x0: array(state_size)
-            Initial state of simulation
-        nsteps: int
-            Total number of steps to sample from the system
-
-        Returns
-        -------
-        * array(nsamples, state_size)
-            State-space values
-        * array(nsamples, obs_size)
-            Observed-space values
-        """
-        key, key_system_noise, key_obs_noise = random.split(key, 3)
-
-        state_hist = jnp.zeros((nsteps, self.d))
-        obs_hist = jnp.zeros((nsteps, self.d))
-
-        state_t = x0.copy()
-        obs_t = self.fx(state_t)
-
-        state_noise = random.multivariate_normal(key_system_noise, jnp.zeros((self.d,)), self.Q, (nsteps,))
-        obs_noise = random.multivariate_normal(key_obs_noise, jnp.zeros((self.d,)), self.R, (nsteps,))
-        state_hist = index_update(state_hist, 0, state_t)
-        obs_hist = index_update(obs_hist, 0, obs_t)
-
-        for t in range(1, nsteps):
-            state_t = self.fz(state_t) + state_noise[t]
-            obs_t = self.fx(state_t) + obs_noise[t]
-
-            state_hist = index_update(state_hist, t, state_t)
-            obs_hist = index_update(obs_hist, t, obs_t)
-        
-        return state_hist, obs_hist
-
     def filter(self, init_state, sample_obs):
         """
         Run the Unscented Kalman Filter algorithm over a set of observed samples.
@@ -385,8 +341,6 @@ class UnscentedKalmanFilter:
             # TO-DO: use jax.scipy.linalg.sqrtm when it gets added to lib
             comp1 = mu_t[:, None] + self.gamma * self.sqrtm(Sigma_t)
             comp2 = mu_t[:, None] - self.gamma * self.sqrtm(Sigma_t)
-            #print('kpm')
-            #print([mu_t.shape, comp1.shape, comp2.shape])
             #sigma_points = jnp.c_[mu_t, comp1, comp2]
             sigma_points = jnp.concatenate((mu_t[:, None], comp1, comp2), axis=1)
 

--- a/scripts/nlds_lib.py
+++ b/scripts/nlds_lib.py
@@ -74,6 +74,9 @@ class ExtendedKalmanFilter(NLDS):
     
     @classmethod
     def from_base(cls, model):
+        """
+        Initialise class from an instance of the NLDS parent class
+        """
         return cls(model.fz, model.fx, model.Q, model.R)
 
     def filter(self, init_state, sample_obs):
@@ -292,6 +295,9 @@ class UnscentedKalmanFilter(NLDS):
 
     @classmethod
     def from_base(cls, model, alpha, beta, kappa):
+        """
+        Initialise class from an instance of the NLDS parent class
+        """
         return cls(model.fz, model.fx, model.Q, model.R, alpha, beta, kappa)
     
     @staticmethod


### PR DESCRIPTION
## Description

* Refactor `nlds_lib.py` class
* Refactor `ekf_vs_ukf` demo

### Figures

* No change in output

### Issue 

Closes [issue 216](https://github.com/probml/hermes/issues/216) in Hermes

## Important remarks

For flexibility, I propose the `.from_base` classmethod. This allows us to optionally separate the model initialisation from the "filtering" process. With this classmethod, we can initialise the dynamical system as a separate entity

```python
model = ds.NLDS(lambda x: fz(x, dt), fx, Qt, Rt)
sample_state, sample_obs = model.sample(key, x0, nsteps)
ekf = ds.ExtendedKalmanFilter.from_base(model)
ukf = ds.UnscentedKalmanFilter.from_base(model, alpha, beta, kappa)
```

or implicitly as a single class

```python
ekf = ds.ExtendedKalmanFilter(lambda x: fz(x, dt), fx, Qt, Rt)
sample_state, sample_obs = ekf.sample(key, x0, nsteps)
```