### PR TITLE
create EKF/UKF + MLP

### DIFF
--- a/scripts/ekf_vs_ukf_mlp_demo.py
+++ b/scripts/ekf_vs_ukf_mlp_demo.py
@@ -1,6 +1,13 @@
 # Example of an training of a multilayered perceptron (MLP)
 # using the Extended Kalman Filter (EKF) and the
-# Unscented Kalman Filter
+# Unscented Kalman Filter (UKF)
+# For more information, see
+#   * Neural Network Training Using Unscented and Extended Kalman Filter
+#       https://juniperpublishers.com/raej/RAEJ.MS.ID.555568.php
+#   * UKF-based training algorithm for feed-forward neural networks with
+#     application to XOR classification problem
+#       https://ieeexplore.ieee.org/document/6234549
+
 # Author: Gerardo Durán-Martín (@gerdm)
 
 import jax
@@ -13,6 +20,34 @@ import pyprobml_utils as pml
 from functools import partial
 from numpy.random import shuffle, seed
 from jax.random import PRNGKey, split, normal, multivariate_normal
+
+
+def mlp(W, x, n_hidden):
+    """
+    Multilayer Perceptron (MLP) with a single hidden unit and
+    tanh activation function. The input-unit and the
+    output-unit are both assumed to be unidimensional
+
+    Parameters
+    ----------
+    W: array(2 * n_hidden + n_hidden + 1)
+        Unraveled weights of the MLP
+    x: array(1,)
+        Singleton element to evaluate the MLP
+    n_hidden: int
+        Number of hidden units
+
+    Returns
+    -------
+    * array(1,)
+        Evaluation of MLP at the specified point
+    """
+    W1 = W[:n_hidden].reshape(n_hidden, 1)
+    W2 = W[n_hidden: 2 * n_hidden].reshape(1, n_hidden)
+    b1 = W[2 * n_hidden: 2 * n_hidden + n_hidden]
+    b2 = W[-1]
+    
+    return W2 @ nn.tanh(W1 @ x + b1) + b2
 
 
 def sample_observations(key, f, n_obs, xmin, xmax, x_noise=0.1, y_noise=3.0, shuffle_seed=None):
@@ -37,15 +72,6 @@ def plot_mlp_prediction(key, xobs, yobs, xtest, fw, w, Sw, ax, n_samples=100):
     ax.plot(xtest, sample_yhat.mean(axis=0))
     ax.scatter(xobs, yobs, s=14, c="none", edgecolor="black", label="observations", alpha=0.5)
     ax.set_xlim(xobs.min(), xobs.max())
-
-
-def mlp(W, x, n_hidden):
-    W1 = W[:n_hidden].reshape(n_hidden, 1)
-    W2 = W[n_hidden: 2 * n_hidden].reshape(1, n_hidden)
-    b1 = W[2 * n_hidden: 2 * n_hidden + n_hidden]
-    b2 = W[-1]
-    
-    return W2 @ nn.tanh(W1 @ x + b1) + b2
 
 
 if __name__ == "__main__":

--- a/scripts/ekf_vs_ukf_mlp_demo.py
+++ b/scripts/ekf_vs_ukf_mlp_demo.py
@@ -9,6 +9,7 @@ import nlds_lib as ds
 import flax.linen as nn
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
+from functools import partial
 from jax.random import PRNGKey, split, normal, multivariate_normal
 
 plt.rcParams["axes.spines.right"] = False
@@ -26,8 +27,8 @@ def sample_observations(key, f, n_obs, xmin, xmax, x_noise=0.1, y_noise=3.0):
     x, y = jnp.array(X.T)
     return x, y
 
-n_hidden = 6
-def fwd_mlp(W, x):
+
+def mlp(W, x, n_hidden):
     W1 = W[:n_hidden].reshape(n_hidden, 1)
     W2 = W[n_hidden: 2 * n_hidden].reshape(1, n_hidden)
     b1 = W[2 * n_hidden: 2 * n_hidden + n_hidden]
@@ -35,6 +36,8 @@ def fwd_mlp(W, x):
     
     return W2 @ nn.tanh(W1 @ x + b1) + b2
 
+n_hidden = 6
+fwd_mlp = partial(mlp, n_hidden=n_hidden)
 def f(x): return x -10 * jnp.cos(x) * jnp.sin(x) + x ** 3
 def fz(W): return W
 
@@ -46,23 +49,21 @@ fwd_mlp_weights = jax.vmap(fwd_mlp, in_axes=[1, None])
 fwd_mlp_obs_weights = jax.vmap(fwd_mlp_obs, in_axes=[0, None])
 
 
+n_obs = 200
+key = PRNGKey(31415)
+key_sample_obs, key_weights = split(key, 2)
+xmin, xmax = -3, 3
+x, y = sample_observations(key_sample_obs, f, n_obs, xmin, xmax)
+
 sigma = 0.1
+n_hidden = 6
 n_in, n_out = 1, 1
 n_params = n_in * n_hidden + n_hidden * n_out  + n_hidden + n_out
 
-n_params = 1 * n_hidden + n_hidden * 1 + n_hidden + 1
-W0 = jnp.zeros((n_params,))
-
-key = PRNGKey(31415)
-W0 = normal(key, (n_params,)) * sigma
+W0 = normal(key_weights, (n_params,)) * sigma
 Q = jnp.eye(n_params) * sigma ** 2
 R = jnp.eye(1) * 0.9
 
-
-n_obs = 200
-key = PRNGKey(314)
-xmin, xmax = -3, 3
-x, y = sample_observations(key, f, n_obs, xmin, xmax)
 
 ekf = ds.ExtendedKalmanFilter(fz, fwd_mlp, Q, R)
 ekf_mu_hist, ekf_Sigma_hist = ekf.filter(W0, y[:, None], x[:, None])

--- a/scripts/ekf_vs_ukf_mlp_demo.py
+++ b/scripts/ekf_vs_ukf_mlp_demo.py
@@ -74,11 +74,14 @@ W_samples = multivariate_normal(key, W_ekf, SW_ekf, (100,))
 xtest = jnp.linspace(x.min(), x.max(), 200)
 sample_yhat_ekf = fwd_mlp_obs_weights(W_samples, xtest[:, None])
 
+
+fig, ax = plt.subplots()
 for sample in sample_yhat_ekf:
-    plt.plot(xtest, sample, c="tab:gray", alpha=0.07)
-plt.plot(xtest, sample_yhat_ekf.mean(axis=0))
-plt.scatter(x, y, s=14, c="none", edgecolor="black", label="observations", alpha=0.5)
-plt.title("EKF + MLP")
+    ax.plot(xtest, sample, c="tab:gray", alpha=0.07)
+ax.plot(xtest, sample_yhat_ekf.mean(axis=0))
+ax.scatter(x, y, s=14, c="none", edgecolor="black", label="observations", alpha=0.5)
+ax.set_xlim(x.min(), x.max())
+ax.set_title("EKF + MLP")
 
 
 alpha, beta, kappa = 1.0, 2.0, 3.0 - n_params
@@ -89,10 +92,13 @@ W_ukf, SW_ukf = ukf_mu_hist[-1], ukf_Sigma_hist[-1]
 W_samples = multivariate_normal(key, W_ukf, SW_ukf, (100,))
 
 sample_yhat_ukf = fwd_mlp_obs_weights(W_samples, xtest[:, None])
+
+fig, ax = plt.subplots()
 for sample in sample_yhat_ukf:
-    plt.plot(xtest, sample, c="tab:gray", alpha=0.07)
-plt.plot(xtest, sample_yhat_ukf.mean(axis=0))
-plt.scatter(x, y, s=14, c="none", edgecolor="black", label="observations", alpha=0.5)
-plt.title("UKF + MLP")
+    ax.plot(xtest, sample, c="tab:gray", alpha=0.07)
+ax.plot(xtest, sample_yhat_ukf.mean(axis=0))
+ax.scatter(x, y, s=14, c="none", edgecolor="black", label="observations", alpha=0.5)
+ax.set_xlim(x.min(), x.max())
+ax.set_title("UKF + MLP")
 
 plt.show()

--- a/scripts/ekf_vs_ukf_mlp_demo.py
+++ b/scripts/ekf_vs_ukf_mlp_demo.py
@@ -1,0 +1,98 @@
+# Example of an training of a multilayered perceptron (MLP)
+# using the Extended Kalman Filter (EKF) and the
+# Unscented Kalman Filter
+# Author: Gerardo Durán-Martín (@gerdm)
+
+import jax
+import numpy as np
+import nlds_lib as ds
+import flax.linen as nn
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+from jax.random import PRNGKey, split, normal, multivariate_normal
+
+plt.rcParams["axes.spines.right"] = False
+plt.rcParams["axes.spines.top"] = False
+
+
+def sample_observations(key, f, n_obs, xmin, xmax, x_noise=0.1, y_noise=3.0):
+    key_x, key_y = split(key, 2)
+    x_noise = normal(key_x, (n_obs,)) * x_noise
+    y_noise = normal(key_y, (n_obs,)) * y_noise
+    x = jnp.linspace(xmin, xmax, n_obs) + x_noise
+    y = f(x) + y_noise
+    X = np.c_[x, y]
+    np.random.shuffle(X)
+    x, y = jnp.array(X.T)
+    return x, y
+
+n_hidden = 6
+def fwd_mlp(W, x):
+    W1 = W[:n_hidden].reshape(n_hidden, 1)
+    W2 = W[n_hidden: 2 * n_hidden].reshape(1, n_hidden)
+    b1 = W[2 * n_hidden: 2 * n_hidden + n_hidden]
+    b2 = W[-1]
+    
+    return W2 @ nn.tanh(W1 @ x + b1) + b2
+
+def f(x): return x -10 * jnp.cos(x) * jnp.sin(x) + x ** 3
+def fz(W): return W
+
+# vectorised for multiple observations
+fwd_mlp_obs = jax.vmap(fwd_mlp, in_axes=[None, 0])
+# vectorised for multiple weights
+fwd_mlp_weights = jax.vmap(fwd_mlp, in_axes=[1, None])
+# vectorised for multiple observations and weights
+fwd_mlp_obs_weights = jax.vmap(fwd_mlp_obs, in_axes=[0, None])
+
+
+sigma = 0.1
+n_in, n_out = 1, 1
+n_params = n_in * n_hidden + n_hidden * n_out  + n_hidden + n_out
+
+n_params = 1 * n_hidden + n_hidden * 1 + n_hidden + 1
+W0 = jnp.zeros((n_params,))
+
+key = PRNGKey(31415)
+W0 = normal(key, (n_params,)) * sigma
+Q = jnp.eye(n_params) * sigma ** 2
+R = jnp.eye(1) * 0.9
+
+
+n_obs = 200
+key = PRNGKey(314)
+xmin, xmax = -3, 3
+x, y = sample_observations(key, f, n_obs, xmin, xmax)
+
+ekf = ds.ExtendedKalmanFilter(fz, fwd_mlp, Q, R)
+ekf_mu_hist, ekf_Sigma_hist = ekf.filter(W0, y[:, None], x[:, None])
+
+step = -1
+W_ekf, SW_ekf = ekf_mu_hist[step], ekf_Sigma_hist[step]
+W_samples = multivariate_normal(key, W_ekf, SW_ekf, (100,))
+
+xtest = jnp.linspace(x.min(), x.max(), 200)
+sample_yhat_ekf = fwd_mlp_obs_weights(W_samples, xtest[:, None])
+
+for sample in sample_yhat_ekf:
+    plt.plot(xtest, sample, c="tab:gray", alpha=0.07)
+plt.plot(xtest, sample_yhat_ekf.mean(axis=0))
+plt.scatter(x, y, s=14, c="none", edgecolor="black", label="observations", alpha=0.5)
+plt.title("EKF + MLP")
+
+
+alpha, beta, kappa = 1.0, 2.0, 3.0 - n_params
+ukf = ds.UnscentedKalmanFilter(fz, lambda w, x: fwd_mlp_weights(w, x).T, Q, R, alpha, beta, kappa)
+ukf_mu_hist, ukf_Sigma_hist = ukf.filter(W0, y, x[:, None])
+
+W_ukf, SW_ukf = ukf_mu_hist[-1], ukf_Sigma_hist[-1]
+W_samples = multivariate_normal(key, W_ukf, SW_ukf, (100,))
+
+sample_yhat_ukf = fwd_mlp_obs_weights(W_samples, xtest[:, None])
+for sample in sample_yhat_ukf:
+    plt.plot(xtest, sample, c="tab:gray", alpha=0.07)
+plt.plot(xtest, sample_yhat_ukf.mean(axis=0))
+plt.scatter(x, y, s=14, c="none", edgecolor="black", label="observations", alpha=0.5)
+plt.title("UKF + MLP")
+
+plt.show()

--- a/scripts/ekf_vs_ukf_mlp_demo.py
+++ b/scripts/ekf_vs_ukf_mlp_demo.py
@@ -10,22 +10,36 @@ import flax.linen as nn
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 from functools import partial
+from numpy.random import shuffle, seed
 from jax.random import PRNGKey, split, normal, multivariate_normal
 
 plt.rcParams["axes.spines.right"] = False
 plt.rcParams["axes.spines.top"] = False
 
 
-def sample_observations(key, f, n_obs, xmin, xmax, x_noise=0.1, y_noise=3.0):
+def sample_observations(key, f, n_obs, xmin, xmax, x_noise=0.1, y_noise=3.0, shuffle_seed=None):
     key_x, key_y = split(key, 2)
     x_noise = normal(key_x, (n_obs,)) * x_noise
     y_noise = normal(key_y, (n_obs,)) * y_noise
     x = jnp.linspace(xmin, xmax, n_obs) + x_noise
     y = f(x) + y_noise
     X = np.c_[x, y]
-    np.random.shuffle(X)
+    seed(shuffle_seed)
+    shuffle(X)
     x, y = jnp.array(X.T)
     return x, y
+
+
+def plot_mlp_prediction(key, xobs, yobs, xtest, fw, w, Sw, ax, n_samples=100):
+    W_samples = multivariate_normal(key, w, Sw, (n_samples,))
+    sample_yhat = fw(W_samples, xtest[:, None])
+
+    for sample in sample_yhat:
+        ax.plot(xtest, sample, c="tab:gray", alpha=0.07)
+    ax.plot(xtest, sample_yhat.mean(axis=0))
+    ax.scatter(xobs, yobs, s=14, c="none", edgecolor="black", label="observations", alpha=0.5)
+    ax.set_xlim(xobs.min(), xobs.max())
+
 
 
 def mlp(W, x, n_hidden):
@@ -36,11 +50,14 @@ def mlp(W, x, n_hidden):
     
     return W2 @ nn.tanh(W1 @ x + b1) + b2
 
-n_hidden = 6
-fwd_mlp = partial(mlp, n_hidden=n_hidden)
 def f(x): return x -10 * jnp.cos(x) * jnp.sin(x) + x ** 3
 def fz(W): return W
 
+# *** MLP configuration ***
+n_hidden = 6
+n_in, n_out = 1, 1
+n_params = n_in * n_hidden + n_hidden * n_out  + n_hidden + n_out
+fwd_mlp = partial(mlp, n_hidden=n_hidden)
 # vectorised for multiple observations
 fwd_mlp_obs = jax.vmap(fwd_mlp, in_axes=[None, 0])
 # vectorised for multiple weights
@@ -48,58 +65,38 @@ fwd_mlp_weights = jax.vmap(fwd_mlp, in_axes=[1, None])
 # vectorised for multiple observations and weights
 fwd_mlp_obs_weights = jax.vmap(fwd_mlp_obs, in_axes=[0, None])
 
-
+# *** Generating training and test data ***
 n_obs = 200
-key = PRNGKey(31415)
+shuffle_seed = 271
+key = PRNGKey(314)
 key_sample_obs, key_weights = split(key, 2)
 xmin, xmax = -3, 3
-x, y = sample_observations(key_sample_obs, f, n_obs, xmin, xmax)
+x, y = sample_observations(key_sample_obs, f, n_obs, xmin, xmax, shuffle_seed=shuffle_seed)
+xtest = jnp.linspace(x.min(), x.max(), n_obs)
 
+# *** MLP Training with xKF ***
 sigma = 0.1
-n_hidden = 6
-n_in, n_out = 1, 1
-n_params = n_in * n_hidden + n_hidden * n_out  + n_hidden + n_out
-
 W0 = normal(key_weights, (n_params,)) * sigma
 Q = jnp.eye(n_params) * sigma ** 2
 R = jnp.eye(1) * 0.9
-
+alpha, beta, kappa = 1.0, 2.0, 3.0 - n_params
+step = -1
 
 ekf = ds.ExtendedKalmanFilter(fz, fwd_mlp, Q, R)
 ekf_mu_hist, ekf_Sigma_hist = ekf.filter(W0, y[:, None], x[:, None])
-
-step = -1
 W_ekf, SW_ekf = ekf_mu_hist[step], ekf_Sigma_hist[step]
-W_samples = multivariate_normal(key, W_ekf, SW_ekf, (100,))
 
-xtest = jnp.linspace(x.min(), x.max(), 200)
-sample_yhat_ekf = fwd_mlp_obs_weights(W_samples, xtest[:, None])
-
-
-fig, ax = plt.subplots()
-for sample in sample_yhat_ekf:
-    ax.plot(xtest, sample, c="tab:gray", alpha=0.07)
-ax.plot(xtest, sample_yhat_ekf.mean(axis=0))
-ax.scatter(x, y, s=14, c="none", edgecolor="black", label="observations", alpha=0.5)
-ax.set_xlim(x.min(), x.max())
-ax.set_title("EKF + MLP")
-
-
-alpha, beta, kappa = 1.0, 2.0, 3.0 - n_params
 ukf = ds.UnscentedKalmanFilter(fz, lambda w, x: fwd_mlp_weights(w, x).T, Q, R, alpha, beta, kappa)
 ukf_mu_hist, ukf_Sigma_hist = ukf.filter(W0, y, x[:, None])
+W_ukf, SW_ukf = ukf_mu_hist[step], ukf_Sigma_hist[step]
 
-W_ukf, SW_ukf = ukf_mu_hist[-1], ukf_Sigma_hist[-1]
-W_samples = multivariate_normal(key, W_ukf, SW_ukf, (100,))
-
-sample_yhat_ukf = fwd_mlp_obs_weights(W_samples, xtest[:, None])
 
 fig, ax = plt.subplots()
-for sample in sample_yhat_ukf:
-    ax.plot(xtest, sample, c="tab:gray", alpha=0.07)
-ax.plot(xtest, sample_yhat_ukf.mean(axis=0))
-ax.scatter(x, y, s=14, c="none", edgecolor="black", label="observations", alpha=0.5)
-ax.set_xlim(x.min(), x.max())
+plot_mlp_prediction(key, x, y, xtest, fwd_mlp_obs_weights, W_ekf, SW_ekf, ax)
+ax.set_title("EKF + MLP")
+
+fig, ax = plt.subplots()
+plot_mlp_prediction(key, x, y, xtest, fwd_mlp_obs_weights, W_ukf, SW_ukf, ax)
 ax.set_title("UKF + MLP")
 
 plt.show()

--- a/scripts/ekf_vs_ukf_mlp_demo.py
+++ b/scripts/ekf_vs_ukf_mlp_demo.py
@@ -30,7 +30,7 @@ def mlp(W, x, n_hidden):
     Parameters
     ----------
     W: array(2 * n_hidden + n_hidden + 1)
-        Unraveled weights of the MLP
+        Unravelled weights of the MLP
     x: array(1,)
         Singleton element to evaluate the MLP
     n_hidden: int

--- a/scripts/ekf_vs_ukf_mlp_demo.py
+++ b/scripts/ekf_vs_ukf_mlp_demo.py
@@ -9,12 +9,10 @@ import nlds_lib as ds
 import flax.linen as nn
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
+import pyprobml_utils as pml
 from functools import partial
 from numpy.random import shuffle, seed
 from jax.random import PRNGKey, split, normal, multivariate_normal
-
-plt.rcParams["axes.spines.right"] = False
-plt.rcParams["axes.spines.top"] = False
 
 
 def sample_observations(key, f, n_obs, xmin, xmax, x_noise=0.1, y_noise=3.0, shuffle_seed=None):
@@ -41,7 +39,6 @@ def plot_mlp_prediction(key, xobs, yobs, xtest, fw, w, Sw, ax, n_samples=100):
     ax.set_xlim(xobs.min(), xobs.max())
 
 
-
 def mlp(W, x, n_hidden):
     W1 = W[:n_hidden].reshape(n_hidden, 1)
     W2 = W[n_hidden: 2 * n_hidden].reshape(1, n_hidden)
@@ -50,53 +47,59 @@ def mlp(W, x, n_hidden):
     
     return W2 @ nn.tanh(W1 @ x + b1) + b2
 
-def f(x): return x -10 * jnp.cos(x) * jnp.sin(x) + x ** 3
-def fz(W): return W
 
-# *** MLP configuration ***
-n_hidden = 6
-n_in, n_out = 1, 1
-n_params = n_in * n_hidden + n_hidden * n_out  + n_hidden + n_out
-fwd_mlp = partial(mlp, n_hidden=n_hidden)
-# vectorised for multiple observations
-fwd_mlp_obs = jax.vmap(fwd_mlp, in_axes=[None, 0])
-# vectorised for multiple weights
-fwd_mlp_weights = jax.vmap(fwd_mlp, in_axes=[1, None])
-# vectorised for multiple observations and weights
-fwd_mlp_obs_weights = jax.vmap(fwd_mlp_obs, in_axes=[0, None])
+if __name__ == "__main__":
+    plt.rcParams["axes.spines.right"] = False
+    plt.rcParams["axes.spines.top"] = False
+    def f(x): return x -10 * jnp.cos(x) * jnp.sin(x) + x ** 3
+    def fz(W): return W
 
-# *** Generating training and test data ***
-n_obs = 200
-shuffle_seed = 271
-key = PRNGKey(314)
-key_sample_obs, key_weights = split(key, 2)
-xmin, xmax = -3, 3
-x, y = sample_observations(key_sample_obs, f, n_obs, xmin, xmax, shuffle_seed=shuffle_seed)
-xtest = jnp.linspace(x.min(), x.max(), n_obs)
+    # *** MLP configuration ***
+    n_hidden = 6
+    n_in, n_out = 1, 1
+    n_params = n_in * n_hidden + n_hidden * n_out  + n_hidden + n_out
+    fwd_mlp = partial(mlp, n_hidden=n_hidden)
+    # vectorised for multiple observations
+    fwd_mlp_obs = jax.vmap(fwd_mlp, in_axes=[None, 0])
+    # vectorised for multiple weights
+    fwd_mlp_weights = jax.vmap(fwd_mlp, in_axes=[1, None])
+    # vectorised for multiple observations and weights
+    fwd_mlp_obs_weights = jax.vmap(fwd_mlp_obs, in_axes=[0, None])
 
-# *** MLP Training with xKF ***
-sigma = 0.1
-W0 = normal(key_weights, (n_params,)) * sigma
-Q = jnp.eye(n_params) * sigma ** 2
-R = jnp.eye(1) * 0.9
-alpha, beta, kappa = 1.0, 2.0, 3.0 - n_params
-step = -1
+    # *** Generating training and test data ***
+    n_obs = 200
+    shuffle_seed = 271
+    key = PRNGKey(314)
+    key_sample_obs, key_weights = split(key, 2)
+    xmin, xmax = -3, 3
+    x, y = sample_observations(key_sample_obs, f, n_obs, xmin, xmax, shuffle_seed=shuffle_seed)
+    xtest = jnp.linspace(x.min(), x.max(), n_obs)
 
-ekf = ds.ExtendedKalmanFilter(fz, fwd_mlp, Q, R)
-ekf_mu_hist, ekf_Sigma_hist = ekf.filter(W0, y[:, None], x[:, None])
-W_ekf, SW_ekf = ekf_mu_hist[step], ekf_Sigma_hist[step]
+    # *** MLP Training with xKF ***
+    sigma = 0.1
+    W0 = normal(key_weights, (n_params,)) * sigma
+    Q = jnp.eye(n_params) * sigma ** 2
+    R = jnp.eye(1) * 0.9
+    alpha, beta, kappa = 1.0, 2.0, 3.0 - n_params
+    step = -1
 
-ukf = ds.UnscentedKalmanFilter(fz, lambda w, x: fwd_mlp_weights(w, x).T, Q, R, alpha, beta, kappa)
-ukf_mu_hist, ukf_Sigma_hist = ukf.filter(W0, y, x[:, None])
-W_ukf, SW_ukf = ukf_mu_hist[step], ukf_Sigma_hist[step]
+    ekf = ds.ExtendedKalmanFilter(fz, fwd_mlp, Q, R)
+    ekf_mu_hist, ekf_Sigma_hist = ekf.filter(W0, y[:, None], x[:, None])
+    W_ekf, SW_ekf = ekf_mu_hist[step], ekf_Sigma_hist[step]
+
+    ukf = ds.UnscentedKalmanFilter(fz, lambda w, x: fwd_mlp_weights(w, x).T, Q, R, alpha, beta, kappa)
+    ukf_mu_hist, ukf_Sigma_hist = ukf.filter(W0, y, x[:, None])
+    W_ukf, SW_ukf = ukf_mu_hist[step], ukf_Sigma_hist[step]
 
 
-fig, ax = plt.subplots()
-plot_mlp_prediction(key, x, y, xtest, fwd_mlp_obs_weights, W_ekf, SW_ekf, ax)
-ax.set_title("EKF + MLP")
+    fig, ax = plt.subplots()
+    plot_mlp_prediction(key, x, y, xtest, fwd_mlp_obs_weights, W_ekf, SW_ekf, ax)
+    ax.set_title("EKF + MLP")
+    pml.savefig("ekf_mlp.pdf")
 
-fig, ax = plt.subplots()
-plot_mlp_prediction(key, x, y, xtest, fwd_mlp_obs_weights, W_ukf, SW_ukf, ax)
-ax.set_title("UKF + MLP")
+    fig, ax = plt.subplots()
+    plot_mlp_prediction(key, x, y, xtest, fwd_mlp_obs_weights, W_ukf, SW_ukf, ax)
+    ax.set_title("UKF + MLP")
+    pml.savefig("ukf_mlp.pdf")
 
-plt.show()
+    plt.show()

--- a/scripts/ekf_vs_ukf_mlp_demo.py
+++ b/scripts/ekf_vs_ukf_mlp_demo.py
@@ -13,7 +13,6 @@
 import jax
 import numpy as np
 import nlds_lib as ds
-import flax.linen as nn
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import pyprobml_utils as pml
@@ -47,7 +46,7 @@ def mlp(W, x, n_hidden):
     b1 = W[2 * n_hidden: 2 * n_hidden + n_hidden]
     b2 = W[-1]
     
-    return W2 @ nn.tanh(W1 @ x + b1) + b2
+    return W2 @ jnp.tanh(W1 @ x + b1) + b2
 
 
 def sample_observations(key, f, n_obs, xmin, xmax, x_noise=0.1, y_noise=3.0, shuffle_seed=None):

--- a/scripts/nlds_lib.py
+++ b/scripts/nlds_lib.py
@@ -100,7 +100,6 @@ class ExtendedKalmanFilter(NLDS):
         nsamples = len(sample_obs)
         Vt = self.Q.copy()
 
-        #mu_t = hidden_states[0]
         mu_t = init_state
 
         mu_hist = jnp.zeros((nsamples, self.state_size))
@@ -109,14 +108,15 @@ class ExtendedKalmanFilter(NLDS):
         mu_hist = index_update(mu_hist, 0, mu_t)
         V_hist = index_update(V_hist, 0, Vt)
 
-        for t in range(1, nsamples):
+        for t in range(nsamples):
             Gt = self.Dfz(mu_t)
             mu_t_cond = self.fz(mu_t)
             Vt_cond = Gt @ Vt @ Gt + self.Q
             Ht = self.Dfx(mu_t_cond)
 
+            xt_hat = self.fx(mu_t_cond, *observations[t])
             Kt = Vt_cond @ Ht.T @ jnp.linalg.inv(Ht @ Vt_cond @ Ht.T + self.R)
-            mu_t = mu_t_cond + Kt @ (sample_obs[t] - self.fx(mu_t_cond))
+            mu_t = mu_t_cond + Kt @ (sample_obs[t] - xt_hat)
             Vt = (I - Kt @ Ht) @ Vt_cond
 
             mu_hist = index_update(mu_hist, t, mu_t)
@@ -340,8 +340,7 @@ class UnscentedKalmanFilter(NLDS):
         wc_vec = jnp.array([1 / (2 * (self.d + self.lmbda)) if i > 0
                             else self.lmbda / (self.d + self.lmbda) + (1 - self.alpha ** 2 + self.beta)
                             for i in range(2 * self.d + 1)])
-        nsteps, _ = sample_obs.shape
-        #mu_t = sample_obs[0]
+        nsteps, *_ = sample_obs.shape
         mu_t = init_state
         Sigma_t = self.Q
 
@@ -351,7 +350,7 @@ class UnscentedKalmanFilter(NLDS):
         mu_hist = index_update(mu_hist, 0, mu_t)
         Sigma_hist = index_update(Sigma_hist, 0, Sigma_t)
 
-        for t in range(1, nsteps):
+        for t in range(nsteps):
             # TO-DO: use jax.scipy.linalg.sqrtm when it gets added to lib
             comp1 = mu_t[:, None] + self.gamma * self.sqrtm(Sigma_t)
             comp2 = mu_t[:, None] - self.gamma * self.sqrtm(Sigma_t)
@@ -363,18 +362,19 @@ class UnscentedKalmanFilter(NLDS):
             Sigma_bar = (z_bar - mu_bar[:, None])
             Sigma_bar = jnp.einsum("i,ji,ki->jk", wc_vec, Sigma_bar, Sigma_bar) + self.Q
 
-            comp1 = mu_bar[:, None] + self.gamma * self.sqrtm(self.Q)
-            comp2 = mu_bar[:, None] - self.gamma * self.sqrtm(self.Q)
+            Sigma_bar_half = self.sqrtm(Sigma_bar)
+            comp1 = mu_bar[:, None] + self.gamma * Sigma_bar_half
+            comp2 = mu_bar[:, None] - self.gamma * Sigma_bar_half
             #sigma_points = jnp.c_[mu_bar, comp1, comp2]
             sigma_points = jnp.concatenate((mu_bar[:, None], comp1, comp2), axis=1)
 
             x_bar = self.fx(z_bar)
             x_hat = x_bar @ wm_vec
-            St = (x_bar - x_hat[:, None])
+            St = x_bar - x_hat[:, None]
             St = jnp.einsum("i,ji,ki->jk", wc_vec, St, St) + self.R
 
-            mu_hat_component = (z_bar - mu_bar[:, None])
-            x_hat_component = (x_bar - x_hat[:, None])
+            mu_hat_component = z_bar - mu_bar[:, None]
+            x_hat_component = x_bar - x_hat[:, None]
             Sigma_bar_y = jnp.einsum("i,ji,ki->jk", wc_vec, mu_hat_component, x_hat_component)
             Kt = Sigma_bar_y @ jnp.linalg.inv(St)
 

--- a/scripts/nlds_lib.py
+++ b/scripts/nlds_lib.py
@@ -113,7 +113,7 @@ class ExtendedKalmanFilter(NLDS):
             Gt = self.Dfz(mu_t)
             mu_t_cond = self.fz(mu_t)
             Vt_cond = Gt @ Vt @ Gt + self.Q
-            Ht = self.Dfx(self.fx(mu_t_cond))
+            Ht = self.Dfx(mu_t_cond)
 
             Kt = Vt_cond @ Ht.T @ jnp.linalg.inv(Ht @ Vt_cond @ Ht.T + self.R)
             mu_t = mu_t_cond + Kt @ (sample_obs[t] - self.fx(mu_t_cond))


### PR DESCRIPTION
## Description

* Refactor `nlds_lib.py`: optional parameters for `fx`
* Fix `nlds_lib.py`: UKF sigma-points specification and use
* Create demo of training a single-layered MLP with EKF and UKF using `nlds_lib.py`

### Figures

<img width="581" alt="ekf-mlp" src="https://user-images.githubusercontent.com/4108759/124870616-ee4f0800-dfba-11eb-8da6-fe5d969ae0b1.png">

<img width="607" alt="ukf-mlp" src="https://user-images.githubusercontent.com/4108759/124870624-f0b16200-dfba-11eb-916a-775a1965353d.png">



### Issue 

Closes [issue 54](https://github.com/probml/hermes/issues/54) in Hermes