### PR TITLE
fix `nlds_lib.py`

### DIFF
--- a/scripts/bootstrap_filter_demo.py
+++ b/scripts/bootstrap_filter_demo.py
@@ -51,9 +51,10 @@ if __name__ == "__main__":
     model = ds.NLDS(lambda x: fz(x, dt), fx, Qt, Rt)
     sample_state, sample_obs = model.sample(key, x0, nsteps)
 
+    n_particles = 3_000
     fz_vec = jax.vmap(fz, in_axes=(0, None))
     particle_filter = ds.BootstrapFiltering(lambda x: fz_vec(x, dt), fx, Qt, Rt)
-    pf_mean = particle_filter.filter(key, x0, sample_obs)
+    pf_mean = particle_filter.filter(key, x0, sample_obs, n_particles)
 
 
     plot_inference(sample_obs, pf_mean)

--- a/scripts/nlds_lib.py
+++ b/scripts/nlds_lib.py
@@ -127,7 +127,7 @@ class ExtendedKalmanFilter(NLDS):
         for t in range(nsamples):
             Gt = self.Dfz(mu_t)
             mu_t_cond = self.fz(mu_t)
-            Vt_cond = Gt @ Vt @ Gt + self.Q
+            Vt_cond = Gt @ Vt @ Gt.T + self.Q
             Ht = self.Dfx(mu_t_cond, *observations[t])
 
             xt_hat = self.fx(mu_t_cond, *observations[t])
@@ -240,7 +240,7 @@ class ContinuousExtendedKalmanFilter:
         return sample_state, sample_obs, jump_size
     
     def _Vt_dot(self, V, G):
-        return G @ V @ G + self.Q
+        return G @ V @ G.T + self.Q
     
     def estimate(self, sample_state, sample_obs, jump_size, dt):
         """


### PR DESCRIPTION
## Description

* Fix bug for the `ExtendedKalmanFilter` and `ContinuousExtendedKalmanFilter` classes: incorrect computation of the filtering step
* Add resampling of points for the bootstrap filtering (as explained in Algorithm 7.5 of  Särkkä)

### Figures

The figures change as follows (left is old, right is new):

Output of `ekf_vs_ukf_demo.py`
<p float="left">
  <img alt="elf-old" src="https://imgur.com/fKw2mPC.png" width="300" />
  <img width="300" alt="ekf-new" src="https://user-images.githubusercontent.com/4108759/128056488-30d6a825-928d-4090-bc57-72717cde412d.png">
</p>

Output of `bootstrap_filter_demo.py`

<p float="left">
  <img width="300" alt="bootstrap-old" src="https://user-images.githubusercontent.com/4108759/128056947-5b53ae90-6408-4e03-9868-41530d8f945a.png">
  <img width="300" alt="bootstrap-new" src="https://user-images.githubusercontent.com/4108759/128057017-1aa141b8-e045-424f-b6ec-9d825879cb01.png">
</p>
