### PR TITLE
Refactor: Move 3d-plots functions to pyprobml_utils

### DIFF
--- a/scripts/mcmc_gmm_demo.py
+++ b/scripts/mcmc_gmm_demo.py
@@ -7,58 +7,14 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import statsmodels.api as sm
-from numpy import linalg
-from scipy.stats import norm, multivariate_normal
-from mpl_toolkits.mplot3d import Axes3D
-from numpy.random import seed, rand, randn
+from scipy.stats import norm
+from numpy.random import rand, randn
 import pyprobml_utils as pml
-
-def kdeg(x, X, h):
-    """
-    KDE under a gaussian kernel
-    
-    Parameters
-    ----------
-    x: array(eval, D)
-    X: array(obs, D)
-    h: float
-
-    Returns
-    -------
-    array(eval):
-        KDE around the observed values
-    """
-    N, D = X.shape
-    nden, _ = x.shape 
-    
-    Xhat = X.reshape(D, 1, N)
-    xhat = x.reshape(D, nden, 1)
-    u = xhat - Xhat
-    u = linalg.norm(u, ord=2, axis=0) ** 2 / (2 * h ** 2)
-    px = np.exp(-u).sum(axis=1) / (N * h * np.sqrt(2 * np.pi))
-    return px
-
-
-def scale_3d(ax, x_scale, y_scale, z_scale, factor=0.62):
-    scale=np.diag([x_scale, y_scale, z_scale, 1.0])
-    scale=scale*(1.0/scale.max())
-    scale[3,3]=factor
-    def short_proj():
-        return np.dot(Axes3D.get_proj(ax), scale)
-    return short_proj
-
-
-def style3d(ax, x_scale, y_scale, z_scale):
-    plt.gca().patch.set_facecolor('white')
-    ax.w_xaxis.set_pane_color((0, 0, 0, 0))
-    ax.w_yaxis.set_pane_color((0, 0, 0, 0))
-    ax.w_zaxis.set_pane_color((0, 0, 0, 0))
-    ax.get_proj = scale_3d(ax, x_scale, y_scale, z_scale)
 
 
 def plot_gmm_3d_trace(trace_hist, π, μ, σ, title, xmin, xmax, ax, h=1, n_eval=500):
     x_eval = np.linspace(xmin, xmax, n_eval)
-    kde_eval = kdeg(x_eval[:, None], trace_hist[:, None], h)
+    kde_eval = pml.kdeg(x_eval[:, None], trace_hist[:, None], h)
     px = norm(μ, σ).pdf(x_eval[:, None]) * π
     px = px.sum(axis=-1)
 
@@ -119,7 +75,7 @@ def sample_plot_gibbs(x0, z0, kv, π, μ, σ, n_iterations, xmin, xmax):
     fig = plt.figure()
     axs = plt.axes(projection="3d")
     plot_gmm_3d_trace(x_hist, π, μ, σ, "Gibbs sampling", xmin, xmax, axs)
-    style3d(axs, 1.5, 1, 0.8)
+    pml.style3d(axs, 1.5, 1, 0.8)
     plt.subplots_adjust(left=0.001, bottom=0.208, right=0.7)
     pml.savefig("gibbs_trace.pdf", pad_inches=0, bbox_inches="tight")
 
@@ -134,7 +90,7 @@ def sample_plot_mh(x0, τ, π, μ, σ, n_iterations, xmin, xmax):
     fig = plt.figure()
     axs = plt.axes(projection="3d")
     plot_gmm_3d_trace(x_hist, π, μ, σ, f"MH with $N(0,{τ}^2)$ proposal", xmin, xmax, axs)
-    style3d(axs, 1.5, 1, 0.8)
+    pml.style3d(axs, 1.5, 1, 0.8)
     plt.subplots_adjust(left=0.001, bottom=0.208)
     pml.savefig(f"mh_trace_{τ}tau.pdf", pad_inches=0, bbox_inches="tight")
 

--- a/scripts/pyprobml_utils.py
+++ b/scripts/pyprobml_utils.py
@@ -155,7 +155,7 @@ def kdeg(x, X, h):
     return px
 
 
-def scale_3d(ax, x_scale, y_scale, z_scale, factor=0.62):
+def scale_3d(ax, x_scale, y_scale, z_scale, factor):
     scale=np.diag([x_scale, y_scale, z_scale, 1.0])
     scale=scale*(1.0/scale.max())
     scale[3,3]=factor
@@ -164,12 +164,12 @@ def scale_3d(ax, x_scale, y_scale, z_scale, factor=0.62):
     return short_proj
 
 
-def style3d(ax, x_scale, y_scale, z_scale):
+def style3d(ax, x_scale, y_scale, z_scale, factor=0.62):
     plt.gca().patch.set_facecolor('white')
     ax.w_xaxis.set_pane_color((0, 0, 0, 0))
     ax.w_yaxis.set_pane_color((0, 0, 0, 0))
     ax.w_zaxis.set_pane_color((0, 0, 0, 0))
-    ax.get_proj = scale_3d(ax, x_scale, y_scale, z_scale)
+    ax.get_proj = scale_3d(ax, x_scale, y_scale, z_scale, factor)
 
 
 if __name__ == "__main__":

--- a/scripts/pyprobml_utils.py
+++ b/scripts/pyprobml_utils.py
@@ -2,6 +2,8 @@
 import os
 import matplotlib.pyplot as plt
 import numpy as np
+from numpy import linalg
+from mpl_toolkits.mplot3d import Axes3D
 
 from inspect import getsourcefile
 from os.path import abspath
@@ -125,6 +127,50 @@ def hinton_diagram(matrix, max_weight=None, ax=None):
     ax.grid(linestyle='--', linewidth=2)
     ax.autoscale_view()
     ax.invert_yaxis()
+
+
+def kdeg(x, X, h):
+    """
+    KDE under a gaussian kernel
+
+    Parameters
+    ----------
+    x: array(eval, D)
+    X: array(obs, D)
+    h: float
+
+    Returns
+    -------
+    array(eval):
+        KDE around the observed values
+    """
+    N, D = X.shape
+    nden, _ = x.shape
+
+    Xhat = X.reshape(D, 1, N)
+    xhat = x.reshape(D, nden, 1)
+    u = xhat - Xhat
+    u = linalg.norm(u, ord=2, axis=0) ** 2 / (2 * h ** 2)
+    px = np.exp(-u).sum(axis=1) / (N * h * np.sqrt(2 * np.pi))
+    return px
+
+
+def scale_3d(ax, x_scale, y_scale, z_scale, factor=0.62):
+    scale=np.diag([x_scale, y_scale, z_scale, 1.0])
+    scale=scale*(1.0/scale.max())
+    scale[3,3]=factor
+    def short_proj():
+        return np.dot(Axes3D.get_proj(ax), scale)
+    return short_proj
+
+
+def style3d(ax, x_scale, y_scale, z_scale):
+    plt.gca().patch.set_facecolor('white')
+    ax.w_xaxis.set_pane_color((0, 0, 0, 0))
+    ax.w_yaxis.set_pane_color((0, 0, 0, 0))
+    ax.w_zaxis.set_pane_color((0, 0, 0, 0))
+    ax.get_proj = scale_3d(ax, x_scale, y_scale, z_scale)
+
 
 if __name__ == "__main__":
     test()

--- a/scripts/rbpf_maneuver_demo.py
+++ b/scripts/rbpf_maneuver_demo.py
@@ -22,60 +22,18 @@ plt.rcParams["axes.spines.right"] = False
 plt.rcParams["axes.spines.top"] = False
 
 
-def kdeg(x, X, h):
-    """
-    KDE under a gaussian kernel
-    
-    Parameters
-    ----------
-    x: array(eval, D)
-    X: array(obs, D)
-    h: float
-    Returns
-    -------
-    array(eval):
-        KDE around the observed values
-    """
-    N, D = X.shape
-    nden, _ = x.shape 
-    
-    Xhat = X.reshape(D, 1, N)
-    xhat = x.reshape(D, nden, 1)
-    u = xhat - Xhat
-    u = linalg.norm(u, ord=2, axis=0) ** 2 / (2 * h ** 2)
-    px = np.exp(-u).sum(axis=1) / (N * h * np.sqrt(2 * np.pi))
-    return px
-
-
-def scale_3d(ax, x_scale, y_scale, z_scale, factor):
-    scale = np.diag([x_scale, y_scale, z_scale, 1.0])
-    scale = scale * (1.0 / scale.max())
-    scale[3,3] = factor
-    def short_proj():
-        return np.dot(Axes3D.get_proj(ax), scale)
-    return short_proj
-
-
-def style3d(ax, x_scale, y_scale, z_scale, factor=0.62):
-    plt.gca().patch.set_facecolor('white')
-    ax.w_xaxis.set_pane_color((0, 0, 0, 0))
-    ax.w_yaxis.set_pane_color((0, 0, 0, 0))
-    ax.w_zaxis.set_pane_color((0, 0, 0, 0))
-    ax.get_proj = scale_3d(ax, x_scale, y_scale, z_scale, factor=factor)
-
-
 def plot_3d_belief_state(mu_hist, dim, ax, skip=3, npoints=2000, azimuth=-30, elevation=30):
     nsteps = len(mu_hist)
     xmin, xmax = mu_hist[..., dim].min(), mu_hist[..., dim].max()
     xrange = jnp.linspace(xmin, xmax, npoints).reshape(-1, 1)
-    res = np.apply_along_axis(lambda X: kdeg(xrange, X[..., None], 0.5), 1, mu_hist)
+    res = np.apply_along_axis(lambda X: pml.kdeg(xrange, X[..., None], 0.5), 1, mu_hist)
     densities = res[..., dim]
     for t in range(0, nsteps, skip):
         tloc = t * np.ones(npoints)
         px = densities[t]
         ax.plot(tloc, xrange, px, c="tab:blue", linewidth=1)
     ax.set_zlim(0, 1)
-    style3d(ax, 1.8, 1.2, 0.7, 0.8)
+    pml.style3d(ax, 1.8, 1.2, 0.7, 0.8)
     ax.view_init(elevation, azimuth)
     ax.set_xlabel(r"$t$", fontsize=13)
     ax.set_ylabel(r"$x_{"f"d={dim}"",t}$", fontsize=13)


### PR DESCRIPTION
## Description

* Refactor `mcmc_gmm_demo.py` and `pyprobml_utils.py` to make use of 3d plot functions in `pyprobml_utils`

### Figures

* No change in figures

### Issue 

Closes [issue #326](https://github.com/probml/hermes/issues/326) in Hermes