### PR TITLE
Create opt_lower_bound.py

### DIFF
--- a/scripts/opt_lower_bound.py
+++ b/scripts/opt_lower_bound.py
@@ -1,0 +1,31 @@
+# Lowerbound illustration
+# This file is based on https://github.com/probml/pmtk3/blob/master/demos/optLowerbound.m
+
+import numpy as np
+import math
+import matplotlib.pyplot as plt
+import pyprobml_utils as pml
+
+start, stop, step = 0, 3, 0.01
+domain = np.arange(start, stop + step, step)
+offset = 0.015
+
+f = lambda x: math.exp(-x) if isinstance(x, int) else np.exp(-x)
+t = lambda x, y: -math.exp(-y) * x + f(y) + math.exp(-y) * y - offset
+
+t1 = lambda x: t(x, 1)
+t2 = lambda x: t(x, 0.5)
+t3 = lambda x: t(x, 2)
+
+plt.plot(domain, t1(domain), '-b', linewidth=3)
+plt.plot(domain, t2(domain), '-g', linewidth=3)
+plt.plot(domain, t3(domain), '-g', linewidth=3)
+plt.plot([1, 1], [0, f(1)], '-k', linewidth=4)
+plt.plot(domain, f(domain), '-r', linewidth=5)
+plt.xlim([start, stop])
+plt.ylim([0, 1])
+plt.text(1 - 1 / 15, 0 - 1 / 15, r'$\epsilon$', {'fontsize': 20})
+plt.xticks([0, 1.5, 3])
+plt.yticks([0, 0.5, 1])
+pml.savefig('opt_lower_bound.pdf', dpi=300)
+plt.show()


### PR DESCRIPTION
## Description
This file is python version of optLowerbound.m

<img width="589" alt="Screenshot 2021-08-19 at 7 27 30 PM" src="https://user-images.githubusercontent.com/66471669/130081553-8bb2c83f-53df-4b96-9b57-a58d9f4d1acd.png">
### Figures

You can put the figures you have attained.

### Issue 

Closes probml/hermes##378

## Potential problems/Important remarks

I couldn't find how to render the annotation present in matlab code, So i used text() to use the string  r'$\epsilon$'

- [ ] Also, will label it if advised.
