### PR TITLE
Refactor `nlds_lib.py`

### DIFF
--- a/scripts/ekf_vs_ukf_demo.py
+++ b/scripts/ekf_vs_ukf_demo.py
@@ -45,17 +45,18 @@ if __name__ == "__main__":
     nsteps = 100
     # Initial state vector
     x0 = jnp.array([1.5, 0.0])
+    state_size, *_ = x0.shape
     # State noise
-    Qt = jnp.eye(2) * 0.001
+    Qt = jnp.eye(state_size) * 0.001
     # Observed noise
     Rt = jnp.eye(2) * 0.05
     alpha, beta, kappa = 1, 0, 2
 
-    key = random.PRNGKey(314)
+    key = random.PRNGKey(31415)
     model = ds.NLDS(lambda x: fz(x, dt), fx, Qt, Rt)
     sample_state, sample_obs = model.sample(key, x0, nsteps)
     ekf = ds.ExtendedKalmanFilter.from_base(model)
-    ukf = ds.UnscentedKalmanFilter.from_base(model, alpha, beta, kappa)
+    ukf = ds.UnscentedKalmanFilter.from_base(model, alpha, beta, kappa, state_size)
 
     ekf_mean_hist, ekf_Sigma_hist = ekf.filter(x0, sample_obs)
     ukf_mean_hist, ukf_Sigma_hist = ukf.filter(x0, sample_obs)

--- a/scripts/nlds_lib.py
+++ b/scripts/nlds_lib.py
@@ -438,11 +438,11 @@ class BootstrapFiltering(NLDS):
 
         key_t, key_reindex, key_next = random.split(key_t, 3)
         # 1. Draw new points from the dynamic model
-        zt_rvs = random.multivariate_normal(key_t, self.fz(zt_rvs), self.Q())
+        zt_rvs = random.multivariate_normal(key_t, self.fz(zt_rvs), self.Q(zt_rvs))
 
         # 2. Calculate unnormalised weights
         xt_rvs = self.fx(zt_rvs)
-        weights_t = stats.multivariate_normal.pdf(obs_t, xt_rvs, self.R())
+        weights_t = stats.multivariate_normal.pdf(obs_t, xt_rvs, self.R(zt_rvs, obs_t))
 
         # 3. Resampling
         pi = random.choice(key_reindex, indices,

--- a/scripts/nlds_lib.py
+++ b/scripts/nlds_lib.py
@@ -31,9 +31,9 @@ class NLDS:
         self.__Q = Q
         self.__R = R
     
-    def Q(self, z):
+    def Q(self, *args):
         if callable(self.__Q):
-            return self.__Q(z)
+            return self.__Q(*args)
         else:
             return self.__Q
     
@@ -47,7 +47,7 @@ class NLDS:
         key, state_t = input_vals
         key_system, key_obs, key = random.split(key, 3)
 
-        state_t = random.multivariate_normal(key_system, self.fz(state_t), self.Q(state_t))
+        state_t = random.multivariate_normal(key_system, self.fz(state_t), self.Q())
         obs_t = random.multivariate_normal(key_obs, self.fx(state_t, *obs), self.R(*obs))
 
         return (key, state_t), (state_t, obs_t)
@@ -124,7 +124,7 @@ class ExtendedKalmanFilter(NLDS):
 
         I = jnp.eye(self.state_size)
         nsamples = len(sample_obs)
-        Vt = self.Q(init_state) if Vinit is None else Vinit
+        Vt = self.Q() if Vinit is None else Vinit
         if observations is None:
             observations = [()] * nsamples
         else:
@@ -141,7 +141,7 @@ class ExtendedKalmanFilter(NLDS):
         for t in range(nsamples):
             Gt = self.Dfz(mu_t)
             mu_t_cond = self.fz(mu_t)
-            Vt_cond = Gt @ Vt @ Gt.T + self.Q(mu_t)
+            Vt_cond = Gt @ Vt @ Gt.T + self.Q()
             Ht = self.Dfx(mu_t_cond, *observations[t])
 
             xt_hat = self.fx(mu_t_cond, *observations[t])
@@ -314,9 +314,9 @@ class UnscentedKalmanFilter(NLDS):
     """
     Implementation of the Unscented Kalman Filter for discrete time systems
     """
-    def __init__(self, fz, fx, Q, R, alpha, beta, kappa):
+    def __init__(self, fz, fx, Q, R, alpha, beta, kappa, d):
         super().__init__(fz, fx, Q, R)
-        self.d, _ = Q.shape
+        self.d = d
         self.alpha = alpha
         self.beta = beta
         self.kappa = kappa
@@ -324,11 +324,11 @@ class UnscentedKalmanFilter(NLDS):
         self.gamma = jnp.sqrt(self.d + self.lmbda)
 
     @classmethod
-    def from_base(cls, model, alpha, beta, kappa):
+    def from_base(cls, model, alpha, beta, kappa, d):
         """
         Initialise class from an instance of the NLDS parent class
         """
-        return cls(model.fz, model.fx, model.Q, model.R, alpha, beta, kappa)
+        return cls(model.fz, model.fx, model.Q, model.R, alpha, beta, kappa, d)
     
     @staticmethod
     def sqrtm(M):
@@ -372,7 +372,7 @@ class UnscentedKalmanFilter(NLDS):
                             for i in range(2 * self.d + 1)])
         nsteps, *_ = sample_obs.shape
         mu_t = init_state
-        Sigma_t = self.Q if Vinit is None else Vinit
+        Sigma_t = self.Q() if Vinit is None else Vinit
         if observations is None:
             observations = [()] * nsteps
         else:
@@ -394,7 +394,7 @@ class UnscentedKalmanFilter(NLDS):
             z_bar = self.fz(sigma_points)
             mu_bar = z_bar @ wm_vec
             Sigma_bar = (z_bar - mu_bar[:, None])
-            Sigma_bar = jnp.einsum("i,ji,ki->jk", wc_vec, Sigma_bar, Sigma_bar) + self.Q
+            Sigma_bar = jnp.einsum("i,ji,ki->jk", wc_vec, Sigma_bar, Sigma_bar) + self.Q()
 
             Sigma_bar_half = self.sqrtm(Sigma_bar)
             comp1 = mu_bar[:, None] + self.gamma * Sigma_bar_half
@@ -405,7 +405,7 @@ class UnscentedKalmanFilter(NLDS):
             x_bar = self.fx(sigma_points, *observations[t])
             x_hat = x_bar @ wm_vec
             St = x_bar - x_hat[:, None]
-            St = jnp.einsum("i,ji,ki->jk", wc_vec, St, St) + self.R
+            St = jnp.einsum("i,ji,ki->jk", wc_vec, St, St) + self.R(*observations[t])
 
             mu_hat_component = z_bar - mu_bar[:, None]
             x_hat_component = x_bar - x_hat[:, None]
@@ -438,11 +438,11 @@ class BootstrapFiltering(NLDS):
 
         key_t, key_reindex, key_next = random.split(key_t, 3)
         # 1. Draw new points from the dynamic model
-        zt_rvs = random.multivariate_normal(key_t, self.fz(zt_rvs), self.Q)
+        zt_rvs = random.multivariate_normal(key_t, self.fz(zt_rvs), self.Q())
 
         # 2. Calculate unnormalised weights
         xt_rvs = self.fx(zt_rvs)
-        weights_t = stats.multivariate_normal.pdf(obs_t, xt_rvs, self.R)
+        weights_t = stats.multivariate_normal.pdf(obs_t, xt_rvs, self.R())
 
         # 3. Resampling
         pi = random.choice(key_reindex, indices,
@@ -469,7 +469,7 @@ class BootstrapFiltering(NLDS):
             mu_hist = jnp.zeros((nsteps, m))
 
             key, key_init = random.split(key, 2)
-            V = self.Q if Vinit is None else Vinit
+            V = self.Q() if Vinit is None else Vinit
             zt_rvs = random.multivariate_normal(key_init, init_state, V, shape=(nsamples,))
             
             init_state = (zt_rvs, key)

--- a/scripts/nlds_lib.py
+++ b/scripts/nlds_lib.py
@@ -31,15 +31,15 @@ class NLDS:
         self.__Q = Q
         self.__R = R
     
-    def Q(self, *args):
+    def Q(self, z, *args):
         if callable(self.__Q):
-            return self.__Q(*args)
+            return self.__Q(z, *args)
         else:
             return self.__Q
     
-    def R(self, *args):
+    def R(self, x, *args):
         if callable(self.__R):
-            return self.__R(*args)
+            return self.__R(x, *args)
         else:
             return self.__R
     
@@ -47,8 +47,8 @@ class NLDS:
         key, state_t = input_vals
         key_system, key_obs, key = random.split(key, 3)
 
-        state_t = random.multivariate_normal(key_system, self.fz(state_t), self.Q())
-        obs_t = random.multivariate_normal(key_obs, self.fx(state_t, *obs), self.R(*obs))
+        state_t = random.multivariate_normal(key_system, self.fz(state_t), self.Q(state_t))
+        obs_t = random.multivariate_normal(key_obs, self.fx(state_t, *obs), self.R(state_t, *obs))
 
         return (key, state_t), (state_t, obs_t)
 
@@ -124,7 +124,7 @@ class ExtendedKalmanFilter(NLDS):
 
         I = jnp.eye(self.state_size)
         nsamples = len(sample_obs)
-        Vt = self.Q() if Vinit is None else Vinit
+        Vt = self.Q(init_state) if Vinit is None else Vinit
         if observations is None:
             observations = [()] * nsamples
         else:
@@ -141,11 +141,11 @@ class ExtendedKalmanFilter(NLDS):
         for t in range(nsamples):
             Gt = self.Dfz(mu_t)
             mu_t_cond = self.fz(mu_t)
-            Vt_cond = Gt @ Vt @ Gt.T + self.Q()
+            Vt_cond = Gt @ Vt @ Gt.T + self.Q(mu_t)
             Ht = self.Dfx(mu_t_cond, *observations[t])
 
             xt_hat = self.fx(mu_t_cond, *observations[t])
-            Kt = Vt_cond @ Ht.T @ jnp.linalg.inv(Ht @ Vt_cond @ Ht.T + self.R(*observations[t]))
+            Kt = Vt_cond @ Ht.T @ jnp.linalg.inv(Ht @ Vt_cond @ Ht.T + self.R(mu_t, *observations[t]))
             mu_t = mu_t_cond + Kt @ (sample_obs[t] - xt_hat)
             Vt = (I - Kt @ Ht) @ Vt_cond
 
@@ -372,7 +372,7 @@ class UnscentedKalmanFilter(NLDS):
                             for i in range(2 * self.d + 1)])
         nsteps, *_ = sample_obs.shape
         mu_t = init_state
-        Sigma_t = self.Q() if Vinit is None else Vinit
+        Sigma_t = self.Q(init_state) if Vinit is None else Vinit
         if observations is None:
             observations = [()] * nsteps
         else:
@@ -394,7 +394,7 @@ class UnscentedKalmanFilter(NLDS):
             z_bar = self.fz(sigma_points)
             mu_bar = z_bar @ wm_vec
             Sigma_bar = (z_bar - mu_bar[:, None])
-            Sigma_bar = jnp.einsum("i,ji,ki->jk", wc_vec, Sigma_bar, Sigma_bar) + self.Q()
+            Sigma_bar = jnp.einsum("i,ji,ki->jk", wc_vec, Sigma_bar, Sigma_bar) + self.Q(mu_t)
 
             Sigma_bar_half = self.sqrtm(Sigma_bar)
             comp1 = mu_bar[:, None] + self.gamma * Sigma_bar_half
@@ -405,7 +405,7 @@ class UnscentedKalmanFilter(NLDS):
             x_bar = self.fx(sigma_points, *observations[t])
             x_hat = x_bar @ wm_vec
             St = x_bar - x_hat[:, None]
-            St = jnp.einsum("i,ji,ki->jk", wc_vec, St, St) + self.R(*observations[t])
+            St = jnp.einsum("i,ji,ki->jk", wc_vec, St, St) + self.R(mu_t, *observations[t])
 
             mu_hat_component = z_bar - mu_bar[:, None]
             x_hat_component = x_bar - x_hat[:, None]
@@ -469,7 +469,7 @@ class BootstrapFiltering(NLDS):
             mu_hist = jnp.zeros((nsteps, m))
 
             key, key_init = random.split(key, 2)
-            V = self.Q() if Vinit is None else Vinit
+            V = self.Q(init_state) if Vinit is None else Vinit
             zt_rvs = random.multivariate_normal(key_init, init_state, V, shape=(nsamples,))
             
             init_state = (zt_rvs, key)

--- a/scripts/pendulum_1d_demo.py
+++ b/scripts/pendulum_1d_demo.py
@@ -66,9 +66,10 @@ colors = ["tab:red" if samp else "tab:blue" for samp in samples_map]
 
 # *** Perform filtering ****
 alpha, beta, kappa = 1, 0, 2
-Vinit = jnp.eye(2)
+state_size = 2
+Vinit = jnp.eye(state_size)
 ekf = ds.ExtendedKalmanFilter.from_base(model)
-ukf = ds.UnscentedKalmanFilter.from_base(model, alpha, beta, kappa)
+ukf = ds.UnscentedKalmanFilter.from_base(model, alpha, beta, kappa, state_size)
 particle_filter = ds.BootstrapFiltering(fz_vec, fx_vmap, Q, Rt)
 
 print("Filtering data...")


### PR DESCRIPTION
## Description
* The state-space and observed-space covariance matrix are now, optionally, a function of the previous state-space. This refactor will be used to complete [issue 358](https://github.com/probml/hermes/issues/358) in Hermes
* Modify `sample` method to use `jax.lax.scan`
* Modify examples that depend on `nlds_lib.py` to make use of the new API

### Figures
Due to the different generating-data process, the `ekf_vs_ukd_demo.py` plot changes as follows:

<p align="left">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/4108759/130462528-d5dede1e-9e94-4949-949c-bf2208613840.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/4108759/130462580-ddb021ce-f373-42b4-b486-0ff82accf51d.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/4108759/130462625-2a5ef9ee-66fb-4580-a669-b7636bbaa441.png">
</p>

