### PR TITLE
Fix: sklearn model import and initialization

### DIFF
--- a/scripts/perceptron_demo_2d.py
+++ b/scripts/perceptron_demo_2d.py
@@ -123,8 +123,8 @@ for t in snapshots:
 '''
 
 # sklearn version
-from sklearn.linear_model import perceptron
-net_sklearn = perceptron.Perceptron()
+from sklearn.linear_model import Perceptron
+net_sklearn = Perceptron()
 net_sklearn.fit(X, y)
 w = net_sklearn.coef_[0]
 offset = net_sklearn.intercept_[0]


### PR DESCRIPTION
## Description
Could not import the scikit-learn perceptron model when running the code locally. Very minor changes to the import and initialization lines to fix the issue.

## Checklist:

- [x] Performed a self-review of the code
- [x] Tested on Google Colab.