### PR TITLE
Fix `visualize_model` for `cpd.values.ndim > 2`

### DIFF
--- a/scripts/pgmpy_utils.py
+++ b/scripts/pgmpy_utils.py
@@ -60,6 +60,8 @@ def visualize_model(model):
     states = get_state_names(model, name)
     cpd = model.get_cpds(name)
     values = cpd.values
+    if values.ndim > 2:
+      values = values.reshape(values.shape[0], -1)
     values = values.T
     the_string = ""
 
@@ -85,7 +87,6 @@ def visualize_model(model):
       r, c = get_lengths(states, name)
       rows = np.prod(r) + 1
       cols = c + 1
-      values = values.reshape(rows-1, cols-1)
       row_string = ""
       for row in range(rows):
         col_string = ""


### PR DESCRIPTION
## Description

This bug is caused by taking the transpose of the `values` array before reshaping it into an `n x m` matrix. It's not a problem when `cpd.values.ndim <= 2` but at higher dimensions, the dimensions get mixed up.

### Figure Number

Volume 02 - Figure 4.2

### Figures
https://gist.github.com/UmarJ/19cf663ec4f9033841d3c166d31d3ba8

The gist also has another example.

### Issue 

Resolves #733