### PR TITLE
Replace deprecated `jax.tree_multimap` with `jax.tree_map`

### DIFF
--- a/scripts/conditional_bernoulli_mix_utils.py
+++ b/scripts/conditional_bernoulli_mix_utils.py
@@ -73,7 +73,7 @@ def fake_test_data(test_words, dataset, targets, L, type_, rng_key=None):
 
         get_img_index = lambda key, target: jax.random.choice(key, jnp.where(targets_with_blank == target)[0])
 
-        img_indices = jax.tree_multimap(get_img_index, keys_, classes.tolist())
+        img_indices = jax.tree_map(get_img_index, keys_, classes.tolist())
         test_images.append(dataset_with_blank[img_indices, ...])
     return test_images
 

--- a/scripts/fit_flax.py
+++ b/scripts/fit_flax.py
@@ -176,7 +176,7 @@ def test():
   params_new, history =  fit_model(
     model, rng, num_steps, train_iter, test_iter)
 
-  diff = tree_util.tree_multimap(lambda x,y: x-y, params_init, params_new)
+  diff = tree_util.tree_map(lambda x,y: x-y, params_init, params_new)
   print(diff)
   norm = l2norm_sq(diff)
   assert norm > 0 # check that parameters have changed :)

--- a/scripts/mix_gauss_mle_vs_map_jax.py
+++ b/scripts/mix_gauss_mle_vs_map_jax.py
@@ -6,7 +6,7 @@ import superimport
 
 import jax.numpy as jnp
 from jax.random import PRNGKey, split, normal
-from jax import tree_multimap
+from jax.tree_util import tree_map
 
 import matplotlib.pyplot as plt
 from numpy.linalg import cholesky
@@ -96,8 +96,8 @@ Sigma3_base = jnp.array([[1, 0.9], [0.9, 1]])
 sigmas = init_sigma((Sigma1_base, Sigma2_base, Sigma3_base), test_dims)
 
 samples = init_samples(mu_base, sigmas, test_dims, keys, n_samples)
-hist_ml, hist_map = jnp.array(tree_multimap(lambda X, Sigma, dim: attempt_em_fit(X, Sigma, pi, dim),
-                                            samples, sigmas, test_dims.tolist())).T
+hist_ml, hist_map = jnp.array(tree_map(lambda X, Sigma, dim: attempt_em_fit(X, Sigma, pi, dim),
+                                       samples, sigmas, test_dims.tolist())).T
 
 fig, ax = plt.subplots()
 ax.plot(test_dims, hist_ml, c="tab:red", marker="o", label="MLE")


### PR DESCRIPTION
## Description

Replace deprecated `jax.tree_multimap` with `jax.tree_map` to avoid the deprecation warning.

```
xxx/.venv/lib/python3.10/site-packages/jax/_src/tree_util.py:189: FutureWarning: jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() instead as a drop-in replacement.
  warnings.warn('jax.tree_util.tree_multimap() is deprecated. Please use jax.tree_util.tree_map() '
```
<!-- Please refer to https://github.com/probml/pyprobml/blob/master/CONTRIBUTING.md before opening this PR -->

### Issue 

[Deprecate jax.tree_util.tree_multimap](https://github.com/google/jax/pull/10126)
[Replace `jax.tree_multimap` with `jax.tree_map`](https://github.com/probml/probml-notebooks/issues/83) (I'm linking the `probml-notebooks` issue. Should I open a separate issue in `pyprobml`?)

<!-- Link the issue you are solving -->

<!-- If the issue is from this repo, include directly with issue number -->
<!-- For example: 

#12

-->

<!-- If the issue is from another repo, you can include it using the regular linking mechanism -->
<!-- For example:

[Issue title](Issue link) 

-->

## Checklist:

- [X] Performed a self-review of the code
- [X] Tested on Google Colab.

## Potential problems/Important remarks

Since `tree_multimap` is just an alias for `tree_map`, I did a very trivial fix with `ag` and `sed`. I have manually reviewed those changes and they all look good to me.


<!-- If you have any important remarks for the reviewers to look at closer,  you can write them in detail here.  -->
