### PR TITLE
Simple parallel CI workflow

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -54,9 +54,16 @@ jobs:
         pytest -n auto -s --verbose tests/test_imports.py
 
   execute_notebooks:
+    strategy:
+      matrix:
+        runner_id: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+    env:
+      PYPROBML_GA_RUNNER_ID: ${{ matrix.runner_id }}
+
     runs-on: ubuntu-latest
     # needs: [check_code_quality, static_import_check]
     container: texlive/texlive:TL2020-historic
+
     steps:
     - name: Clone the reference repository
       uses: actions/checkout@v2

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -55,6 +55,7 @@ jobs:
 
   execute_notebooks:
     strategy:
+      fail-fast: false
       matrix:
         runner_id: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
     env:

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -15,7 +15,8 @@ os.environ["LATEXIFY"] = ""  # To enable latexify code
 # Load notebooks
 notebooks1 = glob("notebooks/book1/*/*.ipynb")
 notebooks2 = glob("notebooks/book2/*/*.ipynb")
-notebooks = notebooks1 + notebooks2
+notebooks = [notebook for i, notebook in enumerate(sorted(notebooks1 + notebooks2))
+        if i % 20 == int(os.environ['PYPROBML_GA_RUNNER_ID'])]
 
 # To make subprocess stdout human readable
 # https://stackoverflow.com/a/38662876


### PR DESCRIPTION
## Description

Dead simple parallel CI workflow with 20 runners. Feel free to increase the number of concurrent jobs to 40 or something as long as it falls under the [usage limit](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits).

### Issue 

https://github.com/probml/pyprobml/issues/783

## Checklist:

- [X] Performed a self-review of the code
- [X] Tested on Google Colab.

## Potential problems/Important remarks

It's too risky to make use of [actions/cache@v3](https://github.com/actions/cache) without pinning the exact version of all packages, so this PR only implements parallel CI.
