### PR TITLE
Combine and publish results from parallel workflows

### DIFF
--- a/.github/scripts/combine_results.py
+++ b/.github/scripts/combine_results.py
@@ -13,7 +13,7 @@ for folder in FOLDERS:
         os.system("rm -rf " + folder)
     os.makedirs(folder)
 
-repo = "https://github.com/patel-zeel/pyprobml.git"
+repo = "https://github.com/probml/pyprobml.git"
 for job in range(n_jobs):
     for folder in FOLDERS:
         branch = f"{folder}_{job}"

--- a/.github/scripts/combine_results.py
+++ b/.github/scripts/combine_results.py
@@ -1,0 +1,25 @@
+import os
+import re
+
+# Read number of jobs
+with open(".github/workflows/notebooks.yml") as f:
+    runners = re.findall("runner_id: (.*)", f.read())
+    n_jobs = len(eval(runners[0]))
+
+# Collect status, logs and figures
+FOLDERS = ["workflow_testing_indicator", "auto_generated_figures"]
+for folder in FOLDERS:
+    if os.path.exists(folder):
+        os.system("rm -rf " + folder)
+    os.makedirs(folder)
+
+repo = "https://github.com/patel-zeel/pyprobml.git"
+for job in range(n_jobs):
+    for folder in FOLDERS:
+        branch = f"{folder}_{job}"
+        if os.path.exists(branch):
+            os.system(f"rm -rf {branch}")
+        os.system(f"git clone --depth 1 --branch {branch} {repo} {branch}")
+        os.system(f"cp -r {branch}/* {folder}")
+        print(f"Copied {branch} to {folder}")
+        os.system(f"rm -rf {branch}")

--- a/.github/scripts/create_dashboard.py
+++ b/.github/scripts/create_dashboard.py
@@ -2,7 +2,10 @@ import os
 from glob import glob
 
 statuses = glob("workflow_testing_indicator/notebooks/*/*/*.png")
-base_url = "https://github.com/patel-zeel/pyprobml/tree/"
+user = "patel-zeel"
+base_url = f"https://github.com/{user}/pyprobml/tree/"
+get_url = lambda x: f'<img width="20" alt="image" src=https://raw.githubusercontent.com/{user}/pyprobml/{x}>'
+get_nb_url = lambda x: os.path.join(base_url, "master", x.split("/", 1)[-1].replace(".png", ".ipynb"))
 
 # sort statuses
 def sort_key(x):
@@ -24,13 +27,16 @@ with open("workflow_testing_indicator/README.md", "w") as f:
     f.write(f"| --- | --- | --- |\n")
     for status in statuses:
         job = status.split("/", 2)[-1].split(".")[0]
-        url = os.path.join(base_url, status)
+        url = get_url(status)
+        url_to_nb = get_nb_url(status)
+        print(url)
+        print(url_to_nb)
         if os.path.exists(status.replace(".png", ".log")):
             log = os.path.join(base_url, status.replace(".png", ".log"))
             log_counter += 1
         else:
             log = "-"
-        f.write(f"| [{job}]({url}) | ![{job}]({url}) | [log]({log}) |\n")
+        f.write(f"| [{job}]({url_to_nb}) | {url} | [log]({log}) |\n")
         file_counter += 1
     f.write(f"\n")
     f.write(f"## Summary\n")

--- a/.github/scripts/create_dashboard.py
+++ b/.github/scripts/create_dashboard.py
@@ -1,0 +1,39 @@
+import os
+from glob import glob
+
+statuses = glob("workflow_testing_indicator/notebooks/*/*/*.png")
+base_url = "https://github.com/patel-zeel/pyprobml/tree/"
+
+# sort statuses
+def sort_key(x):
+    parts = x.split("/")
+    return (parts[-3], parts[-2])
+
+
+statuses = sorted(statuses, key=sort_key)
+
+# write an md file
+log_counter = 0
+file_counter = 0
+with open("workflow_testing_indicator/README.md", "w") as f:
+    f.write(f"# PyProbML status\n")
+    f.write(f"\n")
+    f.write(f"## Status\n")
+    f.write(f"\n")
+    f.write(f"| Job | Status | Log |\n")
+    f.write(f"| --- | --- | --- |\n")
+    for status in statuses:
+        job = status.split("/", 2)[-1].split(".")[0]
+        url = os.path.join(base_url, status)
+        if os.path.exists(status.replace(".png", ".log")):
+            log = os.path.join(base_url, status.replace(".png", ".log"))
+            log_counter += 1
+        else:
+            log = "-"
+        f.write(f"| [{job}]({url}) | ![{job}]({url}) | [log]({log}) |\n")
+        file_counter += 1
+    f.write(f"\n")
+    f.write(f"## Summary\n")
+    f.write(f"\n")
+    f.write(f"In total, {file_counter} jobs were tested.\n")
+    f.write(f"{log_counter} jobs failed.\n")

--- a/.github/scripts/create_dashboard.py
+++ b/.github/scripts/create_dashboard.py
@@ -2,7 +2,7 @@ import os
 from glob import glob
 
 statuses = glob("workflow_testing_indicator/notebooks/*/*/*.png")
-user = "patel-zeel"
+user = "probml"
 base_url = f"https://github.com/{user}/pyprobml/tree/"
 get_url = lambda x: f'<img width="20" alt="image" src=https://raw.githubusercontent.com/{user}/pyprobml/{x}>'
 get_nb_url = lambda x: os.path.join(base_url, "master", x.split("/", 1)[-1].replace(".png", ".ipynb"))

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -118,3 +118,32 @@ jobs:
         publish_dir: test_results/
         publish_branch: workflow_testing_indicator_${{ matrix.runner_id }}
       if: always() && github.event_name == 'push'  # Don't run on pull requests
+
+  combine_and_publish_results:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [execute_notebooks]
+    steps:
+    - name: Clone the reference repository
+      uses: actions/checkout@v2
+
+    - name: Combine and publish results
+      run: |
+        python .github/workflows/scripts/combine_results.py
+        python .github/workflows/scripts/create_dashboard.py
+
+    - name: Push figures to auto_generated_figures (does not run on pull requests)
+      uses: peaceiris/actions-gh-pages@v3.6.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: auto_generated_figures/
+        publish_branch: auto_generated_figures
+      if: github.event_name == 'push'  # Don't run on pull requests
+      
+    - name: Push test-results to workflow_testing_indicator (does not run on pull requests)
+      uses: peaceiris/actions-gh-pages@v3.6.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: workflow_testing_indicator/
+        publish_branch: workflow_testing_indicator
+      if: always() && github.event_name == 'push'  # Don't run on pull requests

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -129,8 +129,8 @@ jobs:
 
     - name: Combine and publish results
       run: |
-        python .github/workflows/scripts/combine_results.py
-        python .github/workflows/scripts/create_dashboard.py
+        python .github/scripts/combine_results.py
+        python .github/scripts/create_dashboard.py
 
     - name: Push figures to auto_generated_figures (does not run on pull requests)
       uses: peaceiris/actions-gh-pages@v3.6.1

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -108,13 +108,13 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: figures/
-        publish_branch: auto_generated_figures
+        publish_branch: auto_generated_figures_${{ matrix.runner_id }}
       if: github.event_name == 'push'  # Don't run on pull requests
-  
+      
     - name: Push test-results to workflow_testing_indicator (does not run on pull requests)
       uses: peaceiris/actions-gh-pages@v3.6.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: test_results/
-        publish_branch: workflow_testing_indicator
+        publish_branch: workflow_testing_indicator_${{ matrix.runner_id }}
       if: always() && github.event_name == 'push'  # Don't run on pull requests

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ GitHub.sublime-settings
 !.vscode/launch.json 
 !.vscode/extensions.json 
 .history
+
+# GitHub Actions
+workflow_testing_indicator*
+auto_generated_figures*

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -22,9 +22,12 @@ timestamped_notebooks = []
 for entry in notebooks_raw.stdout.split("\n"):
     if entry:
         timestamped_notebooks.append(entry.split(" "))
-timestamped_notebooks.sort(reverse=True)    # execute newer notebooks first
-notebooks = [notebook for i, (_, notebook) in enumerate(timestamped_notebooks)
-        if i % 20 == int(os.environ['PYPROBML_GA_RUNNER_ID'])]
+timestamped_notebooks.sort(reverse=True)  # execute newer notebooks first
+notebooks = [
+    notebook
+    for i, (_, notebook) in enumerate(timestamped_notebooks)
+    if i % 20 == int(os.environ["PYPROBML_GA_RUNNER_ID"])
+][:1]
 
 # To make subprocess stdout human readable
 # https://stackoverflow.com/a/38662876

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -27,7 +27,7 @@ notebooks = [
     notebook
     for i, (_, notebook) in enumerate(timestamped_notebooks)
     if i % 20 == int(os.environ["PYPROBML_GA_RUNNER_ID"])
-][:1]
+]
 
 # To make subprocess stdout human readable
 # https://stackoverflow.com/a/38662876


### PR DESCRIPTION
This PR extends the functionality of #792 and partially addresses #783.

After this PR, the workflow will:
* Push figures to `auto_generated_figures` branch
* Push workflow status to `workflow_testing_indicator` branch
* Automatically create a [dashboard](https://github.com/probml/pyprobml/blob/workflow_testing_indicator/README.md) containing the status of the workflow.

Steps:
- [x] Push status, logs, and figures to 20 different branches e.g. `auto_generated_figures_x`, where `x` varies from 0 to 19.
- [x] In the last step, clone the branches and combine the status, logs, and figures into a single folder. Push those single folders to corresponding single branches e.g. `auto_generated_figures`.
- [x] Autogenerate [dashboard](https://github.com/probml/pyprobml/blob/workflow_testing_indicator/README.md) to keep a track of failing notebooks.