### PR TITLE
add pointer in first cell to torch & jax d2l-notebooks

### DIFF
--- a/misc/d2l_notebooks_operations.ipynb
+++ b/misc/d2l_notebooks_operations.ipynb
@@ -1,19 +1,31 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 31,
-   "id": "254ab61d",
+   "cell_type": "markdown",
+   "id": "0d11213c",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import os"
+    "### Add pointer in first cell"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
-   "id": "00df2802",
+   "execution_count": 6,
+   "id": "deef7389",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import nbformat\n",
+    "from probml_utils.url_utils import make_url_from_chapter_no_and_script_name, is_dead_url\n",
+    "\n",
+    "%config Completer.use_jedi = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f291f756",
    "metadata": {},
    "outputs": [
     {
@@ -45,7 +57,7 @@
        " 'lstm': '15'}"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -54,6 +66,53 @@
     "with open(\"d2l_notebooks_mapping.txt\") as fp:\n",
     "    mapping = eval(fp.read())\n",
     "mapping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "811ff860",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relative_path = \"../notebooks/book1\"\n",
+    "switch = {\"torch\": \"jax\", \"jax\": \"torch\"}\n",
+    "\n",
+    "\n",
+    "def add_pointers_in_notebooks(notebook_without_extension, framework, insert=True):\n",
+    "    chapter_no = mapping[notebook]\n",
+    "    path = os.path.join(relative_path, chapter_no, notebook + f\"_{framework}.ipynb\")\n",
+    "    nb = nbformat.read(path, as_version=4)\n",
+    "    url = make_url_from_chapter_no_and_script_name(chapter_no, notebook + f\"_{switch[framework]}.ipynb\")\n",
+    "    if is_dead_url(url):\n",
+    "        print(\"DEAD:\", url)\n",
+    "    sentence = f\"Please find {switch[framework]} implementation of this notebook here: {url}\"\n",
+    "\n",
+    "    if insert:\n",
+    "        nb.cells.insert(0, nbformat.v4.new_markdown_cell(sentence))\n",
+    "    else:\n",
+    "        nb.cells[0][\"source\"] = sentence\n",
+    "    nbformat.write(nb, path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f51f3b63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for notebook in mapping:\n",
+    "    add_pointers_in_notebooks(notebook, \"torch\")\n",
+    "    add_pointers_in_notebooks(notebook, \"jax\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f9a6b34",
+   "metadata": {},
+   "source": [
+    "### Move d2l-notebooks"
    ]
   },
   {
@@ -124,9 +183,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:probml_py3713]",
+   "display_name": "Python [conda env:pymc_exp]",
    "language": "python",
-   "name": "conda-env-probml_py3713-py"
+   "name": "conda-env-pymc_exp-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -138,7 +197,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/book1/09/naive_bayes_mnist_jax.ipynb
+++ b/notebooks/book1/09/naive_bayes_mnist_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/09/naive_bayes_mnist_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "view-in-github"
    },

--- a/notebooks/book1/09/naive_bayes_mnist_torch.ipynb
+++ b/notebooks/book1/09/naive_bayes_mnist_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/09/naive_bayes_mnist_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/13/multi_gpu_training_jax.ipynb
+++ b/notebooks/book1/13/multi_gpu_training_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/13/multi_gpu_training_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "UeG2yP57tJBX"
    },

--- a/notebooks/book1/13/multi_gpu_training_torch.ipynb
+++ b/notebooks/book1/13/multi_gpu_training_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/13/multi_gpu_training_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/14/batchnorm_jax.ipynb
+++ b/notebooks/book1/14/batchnorm_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/14/batchnorm_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "WeuWa9YBJ6Nx"
    },

--- a/notebooks/book1/14/batchnorm_torch.ipynb
+++ b/notebooks/book1/14/batchnorm_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/14/batchnorm_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/14/conv2d_jax.ipynb
+++ b/notebooks/book1/14/conv2d_jax.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/14/conv2d_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<a href=\"https://colab.research.google.com/github/arpitvaghela/probml-notebooks/blob/main/notebooks-d2l/conv2d_jax.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n"
    ]
   },

--- a/notebooks/book1/14/conv2d_torch.ipynb
+++ b/notebooks/book1/14/conv2d_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/14/conv2d_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "n1BilhRQhLSv"
    },

--- a/notebooks/book1/14/densenet_jax.ipynb
+++ b/notebooks/book1/14/densenet_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/14/densenet_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/14/densenet_torch.ipynb
+++ b/notebooks/book1/14/densenet_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/14/densenet_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/14/lenet_jax.ipynb
+++ b/notebooks/book1/14/lenet_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/14/lenet_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/14/lenet_torch.ipynb
+++ b/notebooks/book1/14/lenet_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/14/lenet_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/14/resnet_jax.ipynb
+++ b/notebooks/book1/14/resnet_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/14/resnet_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/14/resnet_torch.ipynb
+++ b/notebooks/book1/14/resnet_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/14/resnet_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/attention_jax.ipynb
+++ b/notebooks/book1/15/attention_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/attention_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "view-in-github"
    },

--- a/notebooks/book1/15/attention_torch.ipynb
+++ b/notebooks/book1/15/attention_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/attention_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/bert_jax.ipynb
+++ b/notebooks/book1/15/bert_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/bert_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c6e7f8c2",
    "metadata": {
     "colab_type": "text",

--- a/notebooks/book1/15/bert_torch.ipynb
+++ b/notebooks/book1/15/bert_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/bert_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/cnn1d_sentiment_jax.ipynb
+++ b/notebooks/book1/15/cnn1d_sentiment_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/cnn1d_sentiment_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "c10QRmlWYxnn"
    },

--- a/notebooks/book1/15/cnn1d_sentiment_torch.ipynb
+++ b/notebooks/book1/15/cnn1d_sentiment_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/cnn1d_sentiment_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/entailment_attention_mlp_jax.ipynb
+++ b/notebooks/book1/15/entailment_attention_mlp_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/entailment_attention_mlp_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "09ca4396",
    "metadata": {
     "colab_type": "text",

--- a/notebooks/book1/15/entailment_attention_mlp_torch.ipynb
+++ b/notebooks/book1/15/entailment_attention_mlp_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/entailment_attention_mlp_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/gru_jax.ipynb
+++ b/notebooks/book1/15/gru_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/gru_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "view-in-github"
    },

--- a/notebooks/book1/15/gru_torch.ipynb
+++ b/notebooks/book1/15/gru_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/gru_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/lstm_jax.ipynb
+++ b/notebooks/book1/15/lstm_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/lstm_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "view-in-github"
    },

--- a/notebooks/book1/15/lstm_torch.ipynb
+++ b/notebooks/book1/15/lstm_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/lstm_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/multi_head_attention_jax.ipynb
+++ b/notebooks/book1/15/multi_head_attention_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/multi_head_attention_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/multi_head_attention_torch.ipynb
+++ b/notebooks/book1/15/multi_head_attention_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/multi_head_attention_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/nmt_attention_jax.ipynb
+++ b/notebooks/book1/15/nmt_attention_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/nmt_attention_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "view-in-github"
    },

--- a/notebooks/book1/15/nmt_attention_torch.ipynb
+++ b/notebooks/book1/15/nmt_attention_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/nmt_attention_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/nmt_jax.ipynb
+++ b/notebooks/book1/15/nmt_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/nmt_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "view-in-github"
    },

--- a/notebooks/book1/15/nmt_torch.ipynb
+++ b/notebooks/book1/15/nmt_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/nmt_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/positional_encoding_jax.ipynb
+++ b/notebooks/book1/15/positional_encoding_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/positional_encoding_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "lRA0TmF0X8m4"
    },

--- a/notebooks/book1/15/positional_encoding_torch.ipynb
+++ b/notebooks/book1/15/positional_encoding_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/positional_encoding_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/rnn_jax.ipynb
+++ b/notebooks/book1/15/rnn_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/rnn_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "view-in-github"
    },

--- a/notebooks/book1/15/rnn_sentiment_jax.ipynb
+++ b/notebooks/book1/15/rnn_sentiment_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/rnn_sentiment_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "zTbiCC6qPdG9"
    },

--- a/notebooks/book1/15/rnn_sentiment_torch.ipynb
+++ b/notebooks/book1/15/rnn_sentiment_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/rnn_sentiment_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/rnn_torch.ipynb
+++ b/notebooks/book1/15/rnn_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/rnn_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/15/transformers_jax.ipynb
+++ b/notebooks/book1/15/transformers_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/transformers_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "m6vJh-hiqW_w"
    },

--- a/notebooks/book1/15/transformers_torch.ipynb
+++ b/notebooks/book1/15/transformers_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/15/transformers_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/19/finetune_cnn_jax.ipynb
+++ b/notebooks/book1/19/finetune_cnn_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/19/finetune_cnn_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "olnmhXymd1Le"
    },

--- a/notebooks/book1/19/finetune_cnn_torch.ipynb
+++ b/notebooks/book1/19/finetune_cnn_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/19/finetune_cnn_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/19/image_augmentation_jax.ipynb
+++ b/notebooks/book1/19/image_augmentation_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/19/image_augmentation_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "YOHLU62T25F1"
    },

--- a/notebooks/book1/19/image_augmentation_torch.ipynb
+++ b/notebooks/book1/19/image_augmentation_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/19/image_augmentation_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"

--- a/notebooks/book1/20/skipgram_jax.ipynb
+++ b/notebooks/book1/20/skipgram_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/20/skipgram_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "dr9s3opBLaxy"
    },

--- a/notebooks/book1/20/skipgram_torch.ipynb
+++ b/notebooks/book1/20/skipgram_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/20/skipgram_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "dr9s3opBLaxy"
    },

--- a/notebooks/book1/20/word_analogies_jax.ipynb
+++ b/notebooks/book1/20/word_analogies_jax.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/20/word_analogies_torch.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "view-in-github"
    },

--- a/notebooks/book1/20/word_analogies_torch.ipynb
+++ b/notebooks/book1/20/word_analogies_torch.ipynb
@@ -2,6 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/20/word_analogies_jax.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"


### PR DESCRIPTION
## Decryption 
Added pointers to torch and Jax version of d2l-notebooks in the first markdown cell. The exact sentence looks like below

1. naive_bayes_mnist_jax.ipynb
_"Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/09/naive_bayes_mnist_torch.ipynb"_ 

2. naive_bayes_mnist_torch.ipynb
_"Please find jax implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/09/naive_bayes_mnist_jax.ipynb"_ 

Dr. @murphyk, let me know if this sentence needs any edits.