### PR TITLE
Add new workflow stage to check latest notebooks

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -63,7 +63,12 @@ jobs:
     - name: Clone the reference repository
       uses: actions/checkout@v3
       with:
-        fetch-depth: 1  # test notebooks touched in the last commit
+        fetch-depth: 2  # fetch latest 2 commits to see which notebooks were touched by the last commit
+
+    - name: Display notebook modification time
+      shell: bash
+      run: |
+        git ls-files 'notebooks/book**.ipynb' -z | xargs -0 -n1 -I{} -- git log -1 --format='%at {}' {} | sort -r
 
     - name: Setup Python 3.7.13 (current colab version)
       shell: bash

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -53,7 +53,63 @@ jobs:
       run: |
         pytest -n auto -s --verbose tests/test_imports.py
 
-  execute_notebooks:
+  execute_latest_notebooks:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [check_code_quality, static_import_check]
+    container: texlive/texlive:TL2020-historic
+
+    steps:
+    - name: Clone the reference repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1  # test notebooks touched in the last commit
+
+    - name: Setup Python 3.7.13 (current colab version)
+      shell: bash
+      run: |
+        curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh --output miniconda.sh
+        mkdir /root/.conda
+        bash miniconda.sh -b
+        rm miniconda.sh
+        echo "export PATH=\"\$HOME/miniconda3/bin:\$PATH\"" >> /root/.bashrc
+        echo "source \"\$HOME/miniconda3/bin/activate\"" >> /root/.bashrc
+        source /root/.bashrc
+        conda create -n py37 python=3.7.13 -y
+        echo "conda activate py37" >> /root/.bashrc
+
+    - name: Install requirements
+      shell: bash
+      run: |
+        source /root/.bashrc
+        pip install -U --no-cache-dir -r requirements-dev.txt | cat
+        pip install -U --no-cache-dir -r requirements.txt | cat
+        apt update && xargs -a requirements-bash.txt apt install -y
+
+    - name: Check code quality (again)
+      shell: bash
+      run: |
+        source /root/.bashrc
+        black --check --verbose notebooks/book1/*/*.ipynb
+        black --check --verbose notebooks/book2/*/*.ipynb
+
+    - name: Cache datasets
+      id: cache-datasets
+      uses: actions/cache@v3
+      with:
+        path: |
+          /root/.keras/datasets
+          /root/tensorflow_datasets
+          ${{ github.workspace }}/data
+        key: datasets
+
+    - name: Check notebooks for errors
+      shell: bash
+      run: |
+        source /root/.bashrc
+        pytest -n auto -s --verbose tests/test_notebooks.py
+
+  execute_all_notebooks:
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +119,7 @@ jobs:
 
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    needs: [check_code_quality, static_import_check]
+    needs: [execute_latest_notebooks]
     container: texlive/texlive:TL2020-historic
 
     steps:
@@ -135,7 +191,7 @@ jobs:
   combine_and_publish_results:
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    needs: [execute_notebooks]
+    needs: [execute_all_notebooks]
     steps:
     - name: Clone the reference repository
       uses: actions/checkout@v2

--- a/notebooks/book1/01/cifar_viz_tf.ipynb
+++ b/notebooks/book1/01/cifar_viz_tf.ipynb
@@ -8,7 +8,7 @@
    "outputs": [],
    "source": [
     "# Based on\n",
-    "# https://github.com/tensorflow/docs/blob/master/site/en/tutorials/keras/basic_classification.ipynb\n",
+    "# https://github.com/tensorflow/docs/blob/master/site/en/r1/tutorials/keras/basic_classification.ipynb\n",
     "# (MIT License)\n",
     "\n",
     "\n",

--- a/notebooks/book1/01/cifar_viz_tf.ipynb
+++ b/notebooks/book1/01/cifar_viz_tf.ipynb
@@ -32,7 +32,6 @@
     "    plt.savefig(os.path.join(figdir, fname))\n",
     "\n",
     "\n",
-    "# print(tf.__version__)\n",
     "np.random.seed(0)\n",
     "\n",
     "\n",

--- a/notebooks/book1/01/emnist_viz_jax.ipynb
+++ b/notebooks/book1/01/emnist_viz_jax.ipynb
@@ -5,7 +5,7 @@
    "id": "7351151b",
    "metadata": {},
    "source": [
-    "Please find torch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/01/emnist_viz_torch.ipynb"
+    "Please find an alternative PyTorch implementation of this notebook here: https://colab.research.google.com/github/probml/pyprobml/blob/master/notebooks/book1/01/emnist_viz_torch.ipynb"
    ]
   },
   {

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -22,7 +22,8 @@ if notebooks_raw.stderr:
 timestamped_notebooks = []
 for entry in notebooks_raw.stdout.split("\n"):
     if entry:
-        timestamped_notebooks.append(entry.split(" "))
+        ts, notebook = entry.split(" ")
+        timestamped_notebooks.append((int(ts), notebook))
 timestamped_notebooks.sort(reverse=True)  # execute newer notebooks first
 if "PYPROBML_GA_RUNNER_ID" in os.environ:
     # we are in execute_all_notebooks
@@ -35,7 +36,7 @@ else:
     # we are in execute_latest_notebooks
     notebooks = []
     oldest_ts, _ = timestamped_notebooks[-1]
-    for (ts, notebook) in enumerate(timestamped_notebooks):
+    for ts, notebook in timestamped_notebooks:
         if ts > oldest_ts:
             notebooks.append(notebooks)
 

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -24,11 +24,20 @@ for entry in notebooks_raw.stdout.split("\n"):
     if entry:
         timestamped_notebooks.append(entry.split(" "))
 timestamped_notebooks.sort(reverse=True)  # execute newer notebooks first
-notebooks = [
-    notebook
-    for i, (_, notebook) in enumerate(timestamped_notebooks)
-    if i % 20 == int(os.environ["PYPROBML_GA_RUNNER_ID"])
-]
+if "PYPROBML_GA_RUNNER_ID" in os.environ:
+    # we are in execute_all_notebooks
+    notebooks = [
+        notebook
+        for i, (_, notebook) in enumerate(timestamped_notebooks)
+        if i % 20 == int(os.environ["PYPROBML_GA_RUNNER_ID"])
+    ]
+else:
+    # we are in execute_latest_notebooks
+    notebooks = []
+    oldest_ts, _ = timestamped_notebooks[-1]
+    for (ts, notebook) in enumerate(timestamped_notebooks):
+        if ts > oldest_ts:
+            notebooks.append(notebooks)
 
 # To make subprocess stdout human readable
 # https://stackoverflow.com/a/38662876

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -38,7 +38,7 @@ else:
     oldest_ts, _ = timestamped_notebooks[-1]
     for ts, notebook in timestamped_notebooks:
         if ts > oldest_ts:
-            notebooks.append(notebooks)
+            notebooks.append(notebook)
 
 # To make subprocess stdout human readable
 # https://stackoverflow.com/a/38662876


### PR DESCRIPTION
## Description

Added a separate step to check the latest modified notebooks to easily find out the problems with them.

I have also added a step named "Display notebook modification time" so that we can check which notebooks have been touched recently, e.g.

```
1652335564 notebooks/book1/01/cifar_viz_tf.ipynb
1652315872 notebooks/book2/20/LVAE.ipynb
1652315872 notebooks/book2/17/gprDemoNoiseFreeAndNoisy.ipynb
1652315872 notebooks/book2/17/gprDemoArd.ipynb
```

### Issue 

https://github.com/probml/pyprobml/issues/783#issuecomment-1124509364

## Potential problems/Important remarks

The new `execute_latest_notebooks` stage is not parallelized to keep things easy on the eyes. We typically don't touch a lot of notebooks in one commit anyway.
