### PR TITLE
Minor bug in computing the energy of ising demo.

### DIFF
--- a/notebooks/book2/04/gibbs_demo_ising.ipynb
+++ b/notebooks/book2/04/gibbs_demo_ising.ipynb
@@ -53,7 +53,7 @@
     "\n",
     "def energy(ix, iy, X, J):\n",
     "    wi = 0\n",
-    "    a = jax.lax.cond(iy > 0, lambda: X[iy - 1, ix], lambda: 0)  # if iy != 0 then add X[iy - 1, ix]\n",
+    "    wi += jax.lax.cond(iy > 0, lambda: X[iy - 1, ix], lambda: 0)  # if iy != 0 then add X[iy - 1, ix]\n",
     "    wi += jax.lax.cond(iy < n_pixels - 1, lambda: X[iy + 1, ix], lambda: 0)\n",
     "    wi += jax.lax.cond(ix > 0, lambda: X[iy, ix - 1], lambda: 0)\n",
     "    wi += jax.lax.cond(ix < n_pixels - 1, lambda: X[iy, ix + 1], lambda: 0)\n",


### PR DESCRIPTION
The contribution of the lower y pixel is assigned to an unused variable a instead of to wi.

## Description

<!-- Please refer to https://github.com/probml/pyprobml/blob/master/CONTRIBUTING.md and/or https://github.com/probml/pyprobml/blob/master/notebooks/README.md before opening this PR -->

### Figure Number

book2 Figure 4.17

### Figures

| Before PR | After PR |
| :-: | :-: |
|![image](https://user-images.githubusercontent.com/12573521/189524494-812bad74-2f3a-4891-8451-e55f1c5039a7.png)|![image](https://user-images.githubusercontent.com/12573521/189524417-256765bc-f14a-413b-9b0f-8ddf3e333482.png)
|![image](https://user-images.githubusercontent.com/12573521/189524519-7c85f243-64fa-45f4-b802-5ad8e61c6f47.png)|![image](https://user-images.githubusercontent.com/12573521/189524454-877105d5-5a2b-4103-bbbd-b8c04ffcdabf.png)
|![image](https://user-images.githubusercontent.com/12573521/189524556-8a827bd9-ec01-47ab-8ef6-9902b476945c.png)|![image](https://user-images.githubusercontent.com/12573521/189524469-a1823eff-baed-4ec7-9642-3c15857a6010.png)|
### Issue 

<!-- Link the issue you are solving.
* If the issue is from this repo, include directly with issue number. For example: #12
* If the issue is from another repo, you can include it using the regular linking mechanism. For example: [Issue title](Issue link)
-->

## Checklist

- [x] Performed a self-review of the code
- [x] Tested on Google Colab.

## Potential problems/Important remarks

At J=0.4 the updated PR has more "clumpiness" than original,  but the phase transition for this model is ~0.44 per Eq. 4.79
