### PR TITLE
Fix `power_method.ipynb`

### DIFF
--- a/notebooks/book1/07/power_method_demo.ipynb
+++ b/notebooks/book1/07/power_method_demo.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Illustrate the powr method for computing largest eigenvector\n",
+    "# Illustrate the power method for computing largest eigenvector\n",
     "\n",
     "\n",
     "import numpy as np\n",
@@ -41,12 +41,16 @@
     "evecs = evecs[:, idx]\n",
     "\n",
     "tol = 1e-3\n",
-    "assert np.allclose(evecs[:, 0], u, tol)\n",
+    "assert np.isclose(np.abs(np.dot(evecs[:, 0], u)), 1, tol)\n",
     "assert np.allclose(evals[0], lam, tol)"
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION


## Description
- The assertion for comparing eigenvectors was failing when the signs of the vectors were opposite. 
Replaced the direct comparison with a dot product check to make the test robust to sign differences.
- Additionally, a minor typo ('powr' -> 'power') in a comment was corrected.

### Issue 
#1126

